### PR TITLE
Magnet volumetric mesh H5M output with Cubit

### DIFF
--- a/ExampleScript.py
+++ b/ExampleScript.py
@@ -1,5 +1,4 @@
 import parastell
-import logging
 
 
 # Define plasma equilibrium VMEC file
@@ -79,14 +78,12 @@ build = {
         }
     }
 }
-# Define number of periods in stellarator plasma
-num_periods = 4
-# Define number of periods to generate
-gen_periods = 1
+# Define number of times to repeat build
+repeat = 0
 # Define number of toroidal cross-sections to make
-num_phi = 60
+num_phi = 61
 # Define number of poloidal points to include in each toroidal cross-section
-num_theta = 60
+num_theta = 61
 # Define magnet coil parameters
 magnets = {
     'file': 'coils.txt',
@@ -102,7 +99,8 @@ magnets = {
 source = {
     'num_s': 11,
     'num_theta': 81,
-    'num_phi': 241
+    'num_phi': 61,
+    'tor_ext': 90.0
 }
 # Define export parameters
 export = {
@@ -124,30 +122,8 @@ export = {
     'bounding_box_atol': 0.00001
 }
 
-# Define logger. Note that this is identical to the default logger instatiated
-# by log.py. If no logger is passed to parametric_stellarator, this is the
-# logger that will be used.
-logger = logging.getLogger('log')
-# Configure base logger message level
-logger.setLevel(logging.INFO)
-# Configure stream handler
-s_handler = logging.StreamHandler()
-# Configure file handler
-f_handler = logging.FileHandler('stellarator.log')
-# Define and set logging format
-format = logging.Formatter(
-    fmt = '%(asctime)s: %(message)s',
-    datefmt = '%H:%M:%S'
-)
-s_handler.setFormatter(format)
-f_handler.setFormatter(format)
-# Add handlers to logger
-logger.addHandler(s_handler)
-logger.addHandler(f_handler)
-
 # Create stellarator
 parastell.parastell(
-    plas_eq, num_periods, build, gen_periods, num_phi, num_theta,
-    magnets = magnets, source = source,
-    export = export, logger = logger
+    plas_eq, build, repeat, num_phi, num_theta,
+    magnets = magnets, source = source, export = export
 )

--- a/ExampleScript.py
+++ b/ExampleScript.py
@@ -1,79 +1,57 @@
 import parastell
+import numpy as np
 
 
 # Define plasma equilibrium VMEC file
 plas_eq = 'plas_eq.nc'
+
+# Define toroidal angles at which radial build is specified.
+# Note that the initial toroidal angle (phi) must be zero
+# Also note that it is generally not advised to have the toroidal extent to
+# extend beyond one stellarator period
+# To build a geometry extending beyond one period, make use of the 'repeat'
+# parameter
+phi_list = [0.0, 22.5, 45.0, 67.5, 90.0]
+# Define poloidal angles at which radial builds is specified.
+# Note that this should always span 360 degrees.
+theta_list = [0.0, 90.0, 180.0, 270.0, 360.0]
+
 # Define radial build
+# For each component, thickness matrices have rows corresponding to toroidal
+# angles (phi_list) and columns corresponding to poloidal angles (theta_list)
 build = {
-    'phi_list': [0.0, 22.5, 45.0, 67.5, 90.0],
-    'theta_list': [0.0, 5.0, 90.0, 175.0, 180.0, 185.0, 270.0, 355.0, 360.0],
+    'phi_list': phi_list,
+    'theta_list': theta_list,
     'wall_s': 1.2,
     'radial_build': {
         'first_wall': {
-            'thickness_matrix': [
-                [5, 5, 5, 5, 5, 5, 5, 5, 5],
-                [5, 5, 5, 5, 5, 5, 5, 5, 5],
-                [5, 5, 5, 5, 5, 5, 5, 5, 5],
-                [5, 5, 5, 5, 5, 5, 5, 5, 5],
-                [5, 5, 5, 5, 5, 5, 5, 5, 5]
-            ]
+            'thickness_matrix': np.ones((len(phi_list), len(theta_list)))*5
         },
         'breeder': {
             'thickness_matrix': [
-                [100, 100, 30, 10, 10, 10, 30, 100, 100],
-                [30,  30,  10, 5,  5,  5,  20, 30,  30],
-                [25,  25,  25, 5,  5,  5,  25, 25,  25],
-                [30,  30,  20, 5,  5,  5,  10, 30,  30],
-                [100, 100, 30, 10, 10, 10, 30, 100, 100]
+                [80, 40, 20, 40, 80],
+                [50, 40, 30, 30, 50],
+                [30, 30, 25, 30, 30],
+                [50, 30, 30, 40, 50],
+                [80, 40, 20, 40, 80]
             ]
         },
         'back_wall': {
-            'thickness_matrix': [
-                [5, 5, 5, 5, 5, 5, 5, 5, 5],
-                [5, 5, 5, 5, 5, 5, 5, 5, 5],
-                [5, 5, 5, 5, 5, 5, 5, 5, 5],
-                [5, 5, 5, 5, 5, 5, 5, 5, 5],
-                [5, 5, 5, 5, 5, 5, 5, 5, 5]
-            ]
+            'thickness_matrix': np.ones((len(phi_list), len(theta_list)))*5
         },
         'shield': {
             'thickness_matrix': [
-                [25, 25, 25, 25, 25, 25, 25, 25, 25],
-                [25, 25, 25, 25, 25, 25, 25, 25, 25],
-                [25, 25, 25, 25, 25, 25, 25, 25, 25],
-                [25, 25, 25, 25, 25, 25, 25, 25, 25],
-                [25, 25, 25, 25, 25, 25, 25, 25, 25]
+                [50, 25, 15, 25, 50],
+                [30, 25, 20, 20, 30],
+                [20, 20, 15, 20, 20],
+                [30, 20, 20, 25, 30],
+                [50, 25, 15, 25, 50]
             ]
-        },
-        'manifolds': {
-            'thickness_matrix': [
-                [50, 50, 15, 5,  5,  5,  15, 50, 50],
-                [20, 20, 5,  5,  5,  5,  15, 20, 20],
-                [15, 15, 15, 5,  5,  5,  15, 15, 15],
-                [20, 20, 15, 5,  5,  5,  5,  20, 20],
-                [50, 50, 15, 5,  5,  5,  15, 50, 50]
-            ]
-        },
-        'gap': {
-            'thickness_matrix': [
-                [5, 5, 5, 5, 5, 5, 5, 5, 5],
-                [5, 5, 5, 5, 5, 5, 5, 5, 5],
-                [5, 5, 5, 5, 5, 5, 5, 5, 5],
-                [5, 5, 5, 5, 5, 5, 5, 5, 5],
-                [5, 5, 5, 5, 5, 5, 5, 5, 5]
-            ],
-            'h5m_tag': 'Vacuum'
         },
         # Note that some neutron transport codes (such as OpenMC) will interpret
         # materials with "vacuum" in the name as void material
         'vacuum_vessel': {
-            'thickness_matrix': [
-                [15, 15, 15, 15, 15, 15, 15, 15, 15],
-                [15, 15, 15, 15, 15, 15, 15, 15, 15],
-                [15, 15, 15, 15, 15, 15, 15, 15, 15],
-                [15, 15, 15, 15, 15, 15, 15, 15, 15],
-                [15, 15, 15, 15, 15, 15, 15, 15, 15]
-            ],
+            'thickness_matrix': np.ones((len(phi_list), len(theta_list)))*15,
             'h5m_tag': 'vac_vessel'
         }
     }
@@ -104,7 +82,7 @@ source = {
 }
 # Define export parameters
 export = {
-    'exclude': ['plasma'],
+    'exclude': [],
     'graveyard': False,
     'step_export': True,
     'h5m_export': 'Cubit',
@@ -123,7 +101,7 @@ export = {
 }
 
 # Create stellarator
-parastell.parastell(
+strengths = parastell.parastell(
     plas_eq, build, repeat, num_phi, num_theta,
     magnets = magnets, source = source, export = export
 )

--- a/magnet_coils.py
+++ b/magnet_coils.py
@@ -1,6 +1,5 @@
 import log
 import cubit
-from pymoab import core, types
 import numpy as np
 from sklearn.preprocessing import normalize
 import os
@@ -23,17 +22,10 @@ def mesh_magnets(vol_ids, logger):
     cwd = os.getcwd()
     base_name = 'coil_mesh'
     general_export_path = f"{cwd}/{base_name}"
-    exo_path = f'{general_export_path}.exo'
     h5m_path = f'{general_export_path}.h5m'
     
-    # EXODUS export
-    cubit.cmd(f'export mesh "{exo_path}"')
-    
-    # Convert EXODUS to H5M
-    mb = core.Core()
-    exodus_set = mb.create_meshset()
-    mb.load_file(exo_path, exodus_set)
-    mb.write_file(h5m_path, [exodus_set])
+    # H5M export
+    cubit.cmd(f'export cf_dagmc "{h5m_path}" overwrite')
 
 
 def cut_mags(tor_ext, vol_ids, r_avg):
@@ -459,6 +451,7 @@ def extract_filaments(file, start, stop, sample):
             if i % sample == 0:
                 # Append coordinates to list
                 coords.append([x, y, z])
+                
         # Otherwise, store filament coordinates but do not append final
         # filament point. In Cubit, continuous curves are created by setting
         # the initial and final vertex indices equal. This is handled in the

--- a/magnet_coils.py
+++ b/magnet_coils.py
@@ -355,10 +355,13 @@ def clean_mag_data(filaments, tor_ext):
             y = coords[1]
             # Compute toroidal angle of point
             phi = np.arctan2(y, x)
+            # Conditionally rotate toroidal angle such that it is positive
+            if phi < 0:
+                phi = phi + 2*np.pi
             # Conditionally iterate counter
             if (
-                phi < np.deg2rad(tor_ext) + tol and
-                phi > 0 - tol
+                phi < np.deg2rad(tor_ext) + tol or
+                phi > 2*np.pi - tol
             ):
                 counter += 1
             

--- a/parastell.py
+++ b/parastell.py
@@ -759,7 +759,7 @@ def parastell(
     # Conditionally build magnet coils and store volume indices
     if magnets is not None:
         magnets['vol_id'] = magnet_coils.magnet_coils(
-            magnets, tor_ext, logger = logger
+            magnets, (repeat + 1) * tor_ext, logger = logger
         )
 
     # Export components

--- a/parastell.py
+++ b/parastell.py
@@ -8,8 +8,8 @@ import cad_to_dagmc
 import numpy as np
 import math
 from scipy.interpolate import RegularGridInterpolator
+from sklearn.preprocessing import normalize
 import os
-from pymoab import core, types
 import inspect
 
 
@@ -75,20 +75,17 @@ def cubit_export(components, export, magnets):
             For a rectangular cross-section, the list format is
             ['rectangle' (str), width (float, cm), thickness (float, cm)]
     """
-    # Extract Cubit export parameters
     facet_tol = export['facet_tol']
     len_tol = export['len_tol']
     norm_tol = export['norm_tol']
+    dir = export['dir']
 
-    # Get current working directory
     cwd = os.getcwd()
 
-    # Import solids
     for name in components.keys():
         cubit.cmd(f'import step "' + cwd + '/' + name + '.step" heal')
         components[name]['vol_id'] = cubit.get_last_id("volume")
 
-    # Imprint and merge all volumes
     cubit.cmd('imprint volume all')
     cubit.cmd('merge volume all')
 
@@ -104,12 +101,10 @@ def cubit_export(components, export, magnets):
     for comp in components.values():
         cubit.cmd(f'group "mat:{comp["h5m_tag"]}" add volume {comp["vol_id"]}')
 
-    # Initialize tolerance strings for export statement as empty strings
     facet_tol_str = ''
     len_tol_str = ''
     norm_tol_str = ''
 
-    # Conditionally fill tolerance strings
     if facet_tol is not None:
         facet_tol_str = f'faceting_tolerance {facet_tol}'
     if len_tol is not None:
@@ -117,10 +112,9 @@ def cubit_export(components, export, magnets):
     if norm_tol is not None:
         norm_tol_str = f'normal_tolerance {norm_tol}'
     
-    # DAGMC export
     cubit.cmd(
-        f'export dagmc "dagmc.h5m" {facet_tol_str} {len_tol_str} {norm_tol_str}'
-        f' make_watertight'
+        f'export dagmc "{dir}dagmc.h5m" {facet_tol_str} {len_tol_str} '
+        f'{norm_tol_str} make_watertight'
     )
 
 
@@ -188,66 +182,35 @@ def exports(export, components, magnets, logger):
             ['rectangle' (str), width (float, cm), thickness (float, cm)]
         logger (object): logger object.
     """
-    # Check that h5m_export has an appropriate value
     if export['h5m_export'] not in [None, 'Cubit', 'Gmsh']:
         raise ValueError(
             'h5m_export must be None or have a string value of \'Cubit\' or '
             '\'Gmsh\''
         )
-    # Check that Cubit export has STEP files to use
     if export['h5m_export'] == 'Cubit' and not export['step_export']:
         raise ValueError('H5M export via Cubit requires STEP files')
-    # Check that H5M export of magnets uses Cubit
     if export['h5m_export'] == 'Gmsh' and magnets is not None:
         raise ValueError(
             'Inclusion of magnets in H5M model requires Cubit export'
         )
     
-    # Conditionally export STEP files
     if export['step_export']:
-        # Signal STEP export
         logger.info('Exporting STEP files...')
         for name, comp in components.items():
             cq.exporters.export(comp['solid'], name + '.step')
-            
-    # Conditionally export tetrahedral mesh
-    if magnets is not None and magnets['meshing']:
-        # Signal STEP export
-        logger.info('Exporting coil mesh...')
-        # Assign export paths
-        cwd = os.getcwd()
-        base_name = 'coil_mesh'
-        general_export_path = f"{cwd}/{base_name}"
-        exo_path = f'{general_export_path}.exo'
-        h5m_path = f'{general_export_path}.h5m'
-        # EXODUS export
-        cubit.cmd(f'export mesh "{exo_path}"')
-        # Convert EXODUS to H5M
-        mb = core.Core()
-        exodus_set = mb.create_meshset()
-        mb.load_file(exo_path, exodus_set)
-        mb.write_file(h5m_path, [exodus_set])
     
-    # Conditinally export H5M file via Cubit
     if export['h5m_export'] == 'Cubit':
-        # Signal H5M export via Cubit
         logger.info('Exporting neutronics H5M file via Cubit...')
-        # Export H5M file via Cubit
         cubit_export(components, export, magnets)
     
-    # Conditionally export H5M file via Gmsh
     if export['h5m_export'] == 'Gmsh':
-        # Signal H5M export via Gmsh
         logger.info('Exporting neutronics H5M file via Gmsh...')
-        # Initialize H5M model
         model = cad_to_dagmc.CadToDagmc()
-        # Extract component data
         for comp in components.values():
             model.add_cadquery_object(
                 comp['solid'],
                 material_tags = [comp['h5m_tag']]
             )
-        # Export H5M file via Gmsh
         model.export_dagmc_h5m_file()
 
 
@@ -271,14 +234,18 @@ def graveyard(vmec, offset, components, logger):
             {'name': {'solid': CadQuery solid (object), 'h5m_tag':
             h5m_tag (string)}}
     """
-    # Signal graveyard generation
     logger.info('Building graveyard...')
     
+    # Define constant to convert from m to cm
+    m2cm = 100
+
     # Determine maximum plasma edge radial position
     R = vmec.vmec2rpz(1.0, 0.0, 0.0)[0]
 
     # Define length of graveyard and convert from m to cm
-    L = 4*(R + offset)*100
+    # Double to cover full geometry
+    # Mutiply by factor of 2 to be conservative
+    L = 2*2*(R + offset)*m2cm
 
     # Create graveyard volume
     graveyard = cq.Workplane("XY").box(L, L, L).shell(5.0,
@@ -294,7 +261,7 @@ def graveyard(vmec, offset, components, logger):
     return components
 
 
-def offset_point(vmec, s, phi, theta, offset, plane_norm):
+def surf_norm(vmec, s, phi, theta, ref_pt, plane_norm):
     """Stellarator offset surface root-finding problem.
 
     Arguments:
@@ -302,35 +269,27 @@ def offset_point(vmec, s, phi, theta, offset, plane_norm):
         s (float): normalized magnetic closed flux surface value.
         phi (float): toroidal angle being solved for (rad).
         theta (float): poloidal angle of interest (rad).
-        offset (float): total offset of layer from plamsa (m).
+        ref_pt (array of float): Cartesian coordinates of plasma edge or
+            scrape-off-layer location (m).
         plane_norm (array of float): normal direction of toroidal plane.
     
     Returns:
-        pt (tuple): (x, y, z) tuple defining Cartesian point offset from
-            stellarator plasma (m).
+        norm (array of float): surface normal direction (m).
     """
-    # Define small value
-    eps = 0.000001
-
-    # Compute Cartesian coordinates of reference point
-    ref_pt = np.array(vmec.vmec2xyz(s, theta, phi))
     # Vary poloidal angle by small amount
+    eps = 0.000001
     next_pt = np.array(vmec.vmec2xyz(s, theta + eps, phi))
     
-    # Take difference from reference point to approximate tangent
-    tang = next_pt - ref_pt
+    tangent = next_pt - ref_pt
 
-    # Compute normal of poloidal profile
-    norm = np.cross(tang, plane_norm)
-    norm = norm/np.linalg.norm(norm)
+    norm = np.cross(plane_norm, tangent)
+    norm = normalize(norm.reshape(-1, 1), axis = 0).ravel()
+    norm = np.array(norm)
 
-    # Define offset point
-    pt = ref_pt + offset*norm
-
-    return pt
+    return norm
 
 
-def offset_surface(vmec, s, theta, phi, offset, plane_norm):
+def offset_point(vmec, s, theta, phi, offset, plane_norm):
     """Computes offset surface point.
 
     Arguments:
@@ -344,18 +303,14 @@ def offset_surface(vmec, s, theta, phi, offset, plane_norm):
     Returns:
         r (array): offset suface point (m).
     """
-    # Conditionally offset poloidal profile
-    # Use VMEC plasma edge value for offset of 0
     if offset == 0:
-        # Compute plasma edge point
         r = np.array(vmec.vmec2xyz(s, theta, phi))
     
-    # Compute offset greater than zero
     elif offset > 0:
-        # Compute offset surface point
-        r = offset_point(vmec, s, phi, theta, offset, plane_norm)
+        ref_pt = np.array(vmec.vmec2xyz(s, theta, phi))
+        norm = surf_norm(vmec, s, phi, theta, ref_pt, plane_norm)
+        r = ref_pt + offset*norm
     
-    # Raise error for negative offset values
     elif offset < 0:
         raise ValueError(
             'Offset must be greater than or equal to 0. Check thickness inputs '
@@ -373,12 +328,12 @@ def stellarator_torus(
     Arguments:
         vmec (object): plasma equilibrium object.
         s (float): normalized magnetic closed flux surface value.
-        tor_ext (float): toroidal extent of build (deg).
+        tor_ext (float): toroidal extent of build (rad).
         repeat (int): number of times to repeat build.
         phi_list_exp (list of float): interpolated list of toroidal angles
-            (deg).
+            (rad).
         theta_list_exp (list of float): interpolated list of poloidal angles
-            (deg).
+            (rad).
         interpolator (object): scipy.interpolate.RegularGridInterpolator object.
         cutter (object): CadQuery solid object used to cut each segment of
             stellarator torus.
@@ -387,70 +342,55 @@ def stellarator_torus(
         torus (object): stellarator torus CadQuery solid object.
         cutter (object): updated cutting volume CadQuery solid object.
     """
-    # Define initial angles defining segment of build
+    # Define initial angles defining segments of build
     initial_angles = np.linspace(
-        tor_ext, tor_ext * repeat, num = repeat
+        np.rad2deg(tor_ext), np.rad2deg(repeat * tor_ext), num = repeat
     )
 
     # Initialize construction
-    period = cq.Workplane("XY")
+    segment = cq.Workplane("XY")
 
-    # Generate poloidal profiles
+    # Define constant to convert from m to cm
+    m2cm = 100
+
     for phi in phi_list_exp:
         # Initialize points in poloidal profile
         pts = []
 
-        # Convert toroidal (phi) angle from degrees to radians
-        phi = np.deg2rad(phi)
-
-        # Compute radial direction of poloidal profile
-        x = np.cos(phi)
-        y = np.sin(phi)
-        dir = np.array([x, y, 0])
         # Compute norm of poloidal profile
-        plane_norm = np.cross(dir, np.array([0, 0, 1]))
-        plane_norm = plane_norm/np.linalg.norm(plane_norm)
+        plane_norm = np.array([-np.sin(phi), np.cos(phi), 0])
 
-        # Compute array of points along poloidal profile
         for theta in theta_list_exp[:-1]:
-            # Convert poloidal (theta) angle from degrees to radians
-            theta = np.deg2rad(theta)
-
-            # Interpolate offset according to toroidal and poloidal angles
-            offset = interpolator([np.rad2deg(phi), np.rad2deg(theta)])[0]
-
-            # Compute offset surface point
-            x, y, z = offset_surface(vmec, s, theta, phi, offset, plane_norm)
-            # Convert from m to cm
-            pt = (x*100, y*100, z*100)
-            # Append point to poloidal profile
+            offset = interpolator([phi, theta])[0]
+            x, y, z = m2cm*offset_point(vmec, s, theta, phi, offset, plane_norm)
+            pt = (x, y, z)
             pts += [pt]
         
         # Ensure final point is same as initial
         pts += [pts[0]]
 
         # Generate poloidal profile
-        period = period.spline(pts).close()
+        segment = segment.spline(pts).close()
     
-    # Loft along poloidal profiles to generate period
-    period = period.loft()
+    # Loft along poloidal profiles to generate segment
+    segment = segment.loft()
 
-    # Conditionally cut period if not plasma volume
+    # Conditionally cut segment if not plasma volume
     if cutter is not None:
-        period_cut = period - cutter
+        segment_cut = segment - cutter
     else:
-        period_cut = period
+        segment_cut = segment
 
     # Update cutting volume
-    cutter = period
+    cutter = segment
 
-    # Initialize torus with conditionally cut period
-    torus = period_cut
+    # Initialize torus with segment
+    torus = segment_cut
 
     # Generate additional profiles
     for angle in initial_angles:
-        period = period_cut.rotate((0, 0, 0), (0, 0, 1), angle)
-        torus = torus.union(period)
+        segment = segment_cut.rotate((0, 0, 0), (0, 0, 1), angle)
+        torus = torus.union(segment)
 
     return torus, cutter
 
@@ -461,22 +401,22 @@ def expand_ang(ang_list, num_ang):
 
     Arguments:
         ang_list (list of float): user-supplied list of toroidal or poloidal
-            angles (deg).
+            angles (rad).
         num_ang (int): number of angles to include in stellarator build.
     
     Returns:
-        ang_list_exp (list of float): interpolated list of angles (deg).
+        ang_list_exp (list of float): interpolated list of angles (rad).
     """
     # Initialize interpolated list of angles
     ang_list_exp = []
 
-    # Compute total angular extent of supplied list
-    ang_ext = ang_list[-1] - ang_list[0]
+    init_ang = ang_list[0]
+    final_ang = ang_list[-1]
+    ang_extent = final_ang - init_ang
 
     # Compute average distance between angles to include in stellarator build
-    ang_diff_avg = ang_ext/(num_ang - 1)
+    ang_diff_avg = ang_extent/(num_ang - 1)
     
-    # Loop over supplied angles
     for ang, next_ang in zip(ang_list[:-1], ang_list[1:]):
         # Compute number of angles to interpolate
         n_ang = math.ceil((next_ang - ang)/ang_diff_avg)
@@ -494,6 +434,7 @@ def expand_ang(ang_list, num_ang):
 
 # Define default export dictionary
 export_def = {
+    'dir': '',
     'exclude': [],
     'graveyard': False,
     'step_export': True,
@@ -530,8 +471,14 @@ def parastell(
             (polidal angle, toroidal angle) pairs. This dictionary takes the
             form
             {
-                'phi_list': list of float (deg),
-                'theta_list': list of float (deg),
+                'phi_list': toroidal angles at which radial build is specified.
+                    This list should always begin at 0.0 and it is advised not
+                    to extend past one stellarator period. To build a geometry
+                    that extends beyond one period, make use of the 'repeat'
+                    parameter (list of float, deg).
+                'theta_list': poloidal angles at which radial build is
+                    specified. This list should always span 360 degrees (list
+                    of float, deg).
                 'wall_s': closed flux index extrapolation at wall (float),
                 'radial_build': {
                     'component': {
@@ -621,42 +568,67 @@ def parastell(
         strengths (list): list of source strengths for each tetrahedron (1/s).
             Returned only if source mesh is generated.
     """
-    # Conditionally instantiate logger
+    export_dict = export_def.copy()
+    export_dict.update(export)
+    
+    if export_dict['h5m_export'] == 'Cubit' or magnets is not None:
+        cubit_dir = os.path.dirname(inspect.getfile(cubit))
+        cubit_dir = cubit_dir + '/plugins/'
+        cubit.init([
+            'cubit',
+            '-nojournal',
+            '-nographics',
+            '-information', 'off',
+            '-warning', 'off',
+            '-commandplugindir',
+            cubit_dir
+        ])
+    
     if logger == None or not logger.hasHandlers():
         logger = log.init()
     
-    # Signal new stellarator build
     logger.info('New stellarator build')
-    
-    # Update export dictionary
-    export_dict = export_def.copy()
-    export_dict.update(export)
     
     # Load plasma equilibrium data
     vmec = read_vmec.vmec_data(plas_eq)
 
-    # Initialize component storage dictionary
     components = {}
     
-    # Extract toroidal (phi) and poloidal (theta) arrays
     phi_list = build['phi_list']
+    phi_list = np.deg2rad(phi_list)
+
+    try:
+        assert phi_list[0] == 0.0, \
+            'Initial toroidal angle not equal to 0. Please redefine ' \
+            'phi_list, beginning at 0.'
+    except AssertionError as e:
+        logger.error(e.args[0])
+        raise e
+    
     theta_list = build['theta_list']
-    # Extract closed flux surface index extrapolation at wall
+    theta_list = np.deg2rad(theta_list)
+
+    try:
+        assert theta_list[-1] - theta_list[0] == 2*np.pi, \
+            'Poloidal extent is not 360 degrees. Please ensure poloidal ' \
+            'angles are specified for one full revolution.'
+    except AssertionError as e:
+        logger.error(e.args[0])
+        raise e
+
     wall_s = build['wall_s']
-    # Extract radial build
     radial_build = build['radial_build']
-    # Extract array dimensions
+    
     n_phi = len(phi_list)
     n_theta = len(theta_list)
 
-    # Compute toroidal extent of build in degrees
+    # Extract toroidal extent of build
     tor_ext = phi_list[-1] - phi_list[0]
 
-    # Check if total toroidal extent exceeds 360 degrees
     try:
-        assert repeat*tor_ext <= 360.0, \
+        assert (repeat + 1)*tor_ext <= 2*np.pi, \
             'Total toroidal extent requested with repeated geometry exceeds ' \
-            '360 degrees'
+            '360 degrees. Please examine phi_list and the repeat parameter.'
     except AssertionError as e:
         logger.error(e.args[0])
         raise e
@@ -688,10 +660,8 @@ def parastell(
     
     # Generate components in radial build
     for name, layer_data in radial_build.items():
-        # Notify which component is being generated
         logger.info(f'Building {name}...')
         
-        # Conditionally assign plasma h5m tag and reference closed flux surface
         if name == 'plasma':
             if export_dict['plas_h5m_tag'] is not None:
                 layer_data['h5m_tag'] = export_dict['plas_h5m_tag']
@@ -699,22 +669,21 @@ def parastell(
         else:
             s = wall_s
 
-        # Conditionally assign scrape-off layer h5m tag
         if name == 'sol':
             if export_dict['sol_h5m_tag'] is not None:
                 layer_data['h5m_tag'] = export_dict['sol_h5m_tag']
         
-        # Conditionally populate h5m tag for layer
         if 'h5m_tag' not in layer_data:
             layer_data['h5m_tag'] = name
 
-        # Extract layer thickness matrix
         thickness_mat = layer_data['thickness_matrix']
-        # Compute offset list, converting from cm to m
+        
+        # Compute total offset matrix, converting from cm to m
         offset_mat += np.array(thickness_mat)/100
 
-        # Build offset interpolator
-        interp = RegularGridInterpolator((phi_list, theta_list), offset_mat)
+        interp = RegularGridInterpolator(
+            (phi_list, theta_list), offset_mat, method = 'cubic'
+        )
         
         # Generate component
         try:
@@ -726,50 +695,26 @@ def parastell(
             logger.error(e.args[0])
             raise e
 
-        # Store solid and name tag
         if name not in export_dict['exclude']:
             components[name] = {}
             components[name]['solid'] = torus
             components[name]['h5m_tag'] = layer_data['h5m_tag']
 
-    # Conditionally build graveyard volume
     if export_dict['graveyard']:
-        # Extract maximum offset
-        offset = max(max(offset_mat))
-        # Build graveyard
-        components = graveyard(vmec, offset, components, logger)
+        max_offset = np.max(offset_mat)
+        components = graveyard(vmec, max_offset, components, logger)
 
-    # Conditionally initialize Cubit
-    if export_dict['h5m_export'] == 'Cubit' or magnets is not None:
-        # Retrieve Cubit module directory
-        cubit_dir = os.path.dirname(inspect.getfile(cubit))
-        # Append plugins directory to Cubit module directory
-        cubit_dir = cubit_dir + '/plugins/'
-        # Initialize Cubit
-        cubit.init([
-            'cubit',
-            '-nojournal',
-            '-nographics',
-            '-information', 'off',
-            '-warning', 'off',
-            '-commandplugindir',
-            cubit_dir
-        ])
-
-    # Conditionally build magnet coils and store volume indices
     if magnets is not None:
         magnets['vol_id'] = magnet_coils.magnet_coils(
-            magnets, (repeat + 1) * tor_ext, logger = logger
+            magnets, (repeat + 1)*tor_ext, logger = logger
         )
 
-    # Export components
     try:
         exports(export_dict, components, magnets, logger)
     except ValueError as e:
         logger.error(e.args[0])
         raise e
     
-    # Conditionally create source mesh
     if source is not None:
         strengths = source_mesh.source_mesh(vmec, source, logger = logger)
         return strengths


### PR DESCRIPTION
Changes the Cubit export of the magnet tetrahedral mesh directly to H5M format, rather than a Cubit export in Exodus format and subsequent conversion to H5M via MOAB. Note that direct export to H5M via Cubit requires Cubit version 2023.11.