### PR TITLE
Add support for NWL calculations

### DIFF
--- a/ExampleScript.py
+++ b/ExampleScript.py
@@ -84,8 +84,10 @@ source = {
 export = {
     'exclude': [],
     'graveyard': False,
+    'dir': '',
     'step_export': True,
     'h5m_export': 'Cubit',
+    'h5m_filename': 'dagmc',
     'plas_h5m_tag': 'Vacuum',
     'sol_h5m_tag': 'Vacuum',
     # Note the following export parameters are used only for Cubit H5M exports

--- a/NWL/NWL.py
+++ b/NWL/NWL.py
@@ -1,0 +1,451 @@
+import numpy as np
+
+
+# Define default export dictionary
+export_def = {
+    'step_export': True,
+    'h5m_export': None,
+    'facet_tol': None,
+    'len_tol': None,
+    'norm_tol': None,
+    'min_mesh_size': 5.0,
+    'max_mesh_size': 20.0,
+    'volume_atol': 0.00001,
+    'center_atol': 0.00001,
+    'bounding_box_atol': 0.00001
+}
+
+
+def NWL_geom(
+        plas_eq, wall_s, tor_ext, num_phi = 61, num_theta = 61, source = None, export = export_def, logger = None
+    ):
+    """Creates DAGMC-compatible neutronics H5M geometry of first wall.
+
+    Arguments:
+        plas_eq (str): path to plasma equilibrium NetCDF file.
+        wall_s (float): closed flux surface label extrapolation at wall.
+        tor_ext (float): toroidal extent to model (deg).
+        num_phi (int): number of phi geometric cross-sections to make for each
+            build segment (defaults to 61).
+        num_theta (int): number of points defining the geometric cross-section
+            (defaults to 61).
+        source (dict): dictionary of source mesh parameters including
+            {
+                'num_s': number of closed magnetic flux surfaces defining mesh
+                    (int),
+                'num_theta': number of poloidal angles defining mesh (int),
+                'num_phi': number of toroidal angles defining mesh (int)
+            }
+        export (dict): dictionary of export parameters including
+            {
+                'exclude': names of components not to export (list of str,
+                    defaults to empty),
+                'graveyard': generate graveyard volume as additional component
+                    (bool, defaults to False),
+                'dir': directory to which to export output files (str, defaults
+                    to empty string). Note that directory must end in '/', if
+                    using Linux or MacOS, or '\' if using Windows.
+                'step_export': export component STEP files (bool, defaults to
+                    True),
+                'h5m_export': export DAGMC-compatible neutronics H5M file using
+                    Cubit or Gmsh. Acceptable values are None or a string value
+                    of 'Cubit' or 'Gmsh' (str, defaults to None). The string is
+                    case-sensitive. Note that if magnets are included, 'Cubit'
+                    must be used,
+                'h5m_filename': name of DAGMC-compatible neutronics H5M file
+                    (str, defaults to 'dagmc'),
+                'plas_h5m_tag': optional alternate material tag to use for
+                    plasma. If none is supplied and the plasma is not excluded,
+                    'plasma' will be used (str, defaults to None),
+                'sol_h5m_tag': optional alternate material tag to use for 
+                    scrape-off layer. If none is supplied and the scrape-off
+                    layer is not excluded, 'sol' will be used (str, defaults to
+                    None),
+                'facet_tol': maximum distance a facet may be from surface of
+                    CAD representation for Cubit export (float, defaults to
+                    None),
+                'len_tol': maximum length of facet edge for Cubit export
+                    (float, defaults to None),
+                'norm_tol': maximum change in angle between normal vector of
+                    adjacent facets (float, defaults to None),
+                'min_mesh_size': minimum mesh element size for Gmsh export
+                    (float, defaults to 5.0),
+                'max_mesh_size': maximum mesh element size for Gmsh export
+                    (float, defaults to 20.0),
+                'volume_atol': absolute volume tolerance to allow when matching
+                    parts in intermediate BREP file with CadQuery parts for
+                    Gmsh export(float, defaults to 0.00001),
+                'center_atol': absolute center coordinates tolerance to allow
+                    when matching parts in intermediate BREP file with CadQuery
+                    parts for Gmsh export (float, defaults to 0.00001),
+                'bounding_box_atol': absolute bounding box tolerance  to allow
+                    when matching parts in intermediate BREP file with CadQuery
+                    parts for Gmsh export (float, defaults to 0.00001).
+            }
+        logger (object): logger object (defaults to None). If no logger is
+            supplied, a default logger will be instantiated.
+
+    Returns:
+        strengths (list): list of source strengths for each tetrahedron (1/s).
+            Returned only if source mesh is generated.
+    """
+    import parastell as ps
+    import source_mesh as sm
+    import log
+    import read_vmec
+    import cubit
+    from scipy.interpolate import RegularGridInterpolator
+    import os
+    import inspect
+    
+    export_dict = export_def.copy()
+    export_dict.update(export)
+    
+    if export_dict['h5m_export'] == 'Cubit':
+        cubit_dir = os.path.dirname(inspect.getfile(cubit))
+        cubit_dir = cubit_dir + '/plugins/'
+        cubit.init([
+            'cubit',
+            '-nojournal',
+            '-nographics',
+            '-information', 'off',
+            '-warning', 'off',
+            '-commandplugindir',
+            cubit_dir
+        ])
+    
+    if logger == None or not logger.hasHandlers():
+        logger = log.init()
+
+    logger.info('Building first wall geometry...')
+    
+    vmec = read_vmec.vmec_data(plas_eq)
+
+    repeat = 0
+
+    # Define arrays of toroidal and poloidal angles of first wall build
+    tor_ext = np.deg2rad(tor_ext)
+    phi_list = np.linspace(0, tor_ext, num = num_phi)
+    theta_list = np.linspace(0, 2*np.pi, num = num_theta)
+    
+    # Define offset matrix
+    offset_mat = np.zeros((num_phi, num_theta))
+    
+    # Define volume used to cut periods
+    cutter = None
+
+    # Build offset interpolator
+    interp = RegularGridInterpolator((phi_list, theta_list), offset_mat)
+
+    # Generate stellarator torus with exterior surface at first wall
+    try:
+        torus, cutter = ps.stellarator_torus(
+            vmec, wall_s, tor_ext, repeat, phi_list, theta_list, interp, cutter
+        )
+    except ValueError as e:
+        logger.error(e.args[0])
+        raise e
+
+    components = {
+        'first_wall': {
+            'solid': torus,
+            'h5m_tag': 'Vacuum'
+        }
+    }
+
+    try:
+        ps.exports(export, components, None, logger)
+    except ValueError as e:
+        logger.error(e.args[0])
+        raise e
+
+    if source is not None:
+        strengths = sm.source_mesh(vmec, source, logger = logger)
+        
+        file = open('strengths.txt', 'w')
+        for tet in strengths:
+            file.write(f'{tet}\n')
+        
+        return strengths
+
+
+def extract_ss(ss_file):
+    """Extracts list of source strengths for each tetrahedron from input file.
+
+    Arguments:
+        ss_file (str): source strength input file.
+
+    Returns:
+        strengths (list): list of source strengths for each tetrahedron (1/s).
+            Returned only if source mesh is generated.
+    """
+    strengths = []
+    
+    file_obj = open(ss_file, 'r')
+    data = file_obj.readlines()
+    for line in data:
+        strengths.append(float(line))
+
+    return strengths
+
+
+def NWL_transport(dagmc_geom, source_mesh, tor_ext, ss_file, num_parts):
+    """Performs neutron transport on first wall geometry via OpenMC.
+
+    Arguments:
+        dagmc_geom (str): path to DAGMC geometry file.
+        source_mesh (str): path to source mesh file.
+        tor_ext (float): toroidal extent of model (deg).
+        ss_file (str): source strength input file.
+        num_parts (int): number of source particles to simulate.
+    """
+    import openmc
+    
+    tor_ext = np.deg2rad(tor_ext)
+    
+    strengths = extract_ss(ss_file)
+
+    # Initialize OpenMC model
+    model = openmc.model.Model()
+
+    dag_univ = openmc.DAGMCUniverse(dagmc_geom, auto_geom_ids = False)
+
+    # Define problem boundaries
+    vac_surf = openmc.Sphere(
+        r = 10000, surface_id = 9999, boundary_type = 'vacuum'
+    )
+    per_init = openmc.YPlane(
+        boundary_type = 'periodic',
+        surface_id = 9991
+    )
+    per_fin = openmc.Plane(
+        a = np.sin(tor_ext),
+        b = -np.cos(tor_ext),
+        c = 0,
+        d = 0,
+        boundary_type = 'periodic',
+        surface_id = 9990
+    )
+
+    # Define first period of geometry
+    region  = -vac_surf & +per_init & +per_fin
+    period = openmc.Cell(cell_id = 9996, region = region, fill = dag_univ)
+    geometry = openmc.Geometry([period])
+    model.geometry = geometry
+
+    # Define run settings
+    settings = openmc.Settings()
+    settings.run_mode = 'fixed source'
+    settings.particles = num_parts
+    settings.batches = 1
+
+    # Define neutron source
+    mesh = openmc.UnstructuredMesh(source_mesh, 'moab')
+    src = openmc.IndependentSource()
+    src.space = openmc.stats.MeshSpatial(
+        mesh, strengths = strengths, volume_normalized = False
+    )
+    src.angle = openmc.stats.Isotropic()
+    src.energy = openmc.stats.Discrete([14.1e6], [1.0])
+    settings.source = [src]
+
+    # Track surface crossings
+    settings.surf_source_write = {
+        'surface_ids': [1],
+        'max_particles': num_parts
+    }
+
+    model.settings = settings
+
+    model.run()
+
+
+def min_problem(theta, vmec, wall_s, phi, pt):
+    """Minimization problem to solve for the poloidal angle.
+
+    Arguments:
+        theta (float): poloidal angle (rad).
+        vmec (object): plasma equilibrium object.
+        wall_s (float): closed flux surface label extrapolation at wall.
+        phi (float): toroidal angle (rad).
+        pt (array of float): Cartesian coordinates of interest (cm).
+
+    Returns:
+        diff (float): L2 norm of difference between coordinates of interest and
+            computed point (cm).
+    """
+    # Compute first wall point
+    fw_pt = np.array(vmec.vmec2xyz(wall_s, theta, phi))
+    m2cm = 100
+    fw_pt = fw_pt*m2cm
+    
+    diff = np.linalg.norm(pt - fw_pt)
+
+    return diff
+
+
+def find_coords(vmec, wall_s, phi, pt):
+    """Solves for poloidal angle of plasma equilibrium corresponding to
+    specified Cartesian coordinates.
+
+    Arguments:
+        vmec (object): plasma equilibrium object.
+        wall_s (float): closed flux surface label extrapolation at wall.
+        phi (float): toroidal angle (rad).
+        pt (array of float): Cartesian coordinates of interest (cm).
+
+    Returns:
+        theta (float): poloidal angle (rad).
+    """
+    from scipy.optimize import direct
+
+    # Solve for the poloidal angle via minimization
+    theta = direct(
+        min_problem,
+        bounds = [(0., 2*np.pi)],
+        args = (vmec, wall_s, phi, pt)
+    )
+    # Extract angle
+    theta = theta.x
+
+    return theta
+
+
+def flux_coords(vmec, wall_s, pt):
+    """Computes flux-coordinate toroidal and poloidal angles corresponding to
+    specified Cartesian coordinates.
+    
+    Arguments:
+        vmec (object): plasma equilibrium object.
+        wall_s (float): closed flux surface label extrapolation at wall.
+        pt (array of float): Cartesian coordinates of interest (cm).
+
+    Returns:
+        phi (float): toroidal angle (rad).
+        theta (float): poloidal angle (rad).
+    """
+    # Extract Cartesian coordinates of original point
+    x, y, z = pt
+    
+    phi = np.arctan2(y, x)
+    theta = find_coords(vmec, wall_s, phi, pt)
+
+    return phi, theta
+
+
+def extract_coords(source_file):
+    """Extracts Cartesian coordinates of particle surface crossings given an
+    OpenMC surface source file.
+
+    Arguments:
+        source_file (str): path to OpenMC surface source file.
+    
+    Returns:
+        coords (array of array of float): Cartesian coordinates of all particle
+            surface crossings.
+    """
+    import h5py
+    
+    # Load source file
+    file = h5py.File(source_file, 'r')
+    # Extract source information
+    dataset = file['source_bank']
+    # Extract coordinates of particle crossings
+    coords = dataset['r']
+
+    return coords
+
+
+def plot(NWL_mat, phi_bins, theta_bins, num_levels):
+    """Generates contour plot of NWL.
+
+    Arguments:
+        NWL_mat (array of array of float): NWL solutions at centroids of
+            (phi, theta) bins (MW).
+        phi_bins (array of float): centroids of toroidal angle bins (rad).
+        theta_bins (array of float): centroids of poloidal angle bins (rad).
+        num_levels (int): number of contour regions.
+    """
+    import matplotlib.pyplot as plt
+    
+    phi_bins = np.rad2deg(phi_bins)
+    theta_bins = np.rad2deg(theta_bins)
+
+    levels = np.linspace(np.min(NWL_mat), np.max(NWL_mat), num = num_levels)
+    fig, ax = plt.subplots()
+    CF = ax.contourf(phi_bins, theta_bins, NWL_mat, levels = levels)
+    cbar = plt.colorbar(CF)
+    cbar.ax.set_ylabel('NWL (MW)')
+    plt.xlabel('Toroidal Angle (degrees)')
+    plt.ylabel('Poloidal Angle (degrees)')
+    fig.savefig('NWL.png')
+
+
+def NWL_plot(
+    source_file, ss_file, plas_eq, tor_ext, pol_ext, wall_s, num_phi = 101, num_theta = 101, num_levels = 10
+    ):
+    """Computes and plots NWL.
+
+    Arguments:
+        source_file (str): path to OpenMC surface source file.
+        ss_file (str): source strength input file.
+        plas_eq (str): path to plasma equilibrium NetCDF file.
+        tor_ext (float): toroidal extent of model (deg).
+        pol_ext (float): poloidal extent of model (deg).
+        wall_s (float): closed flux surface label extrapolation at wall.
+        num_phi (int): number of toroidal angle bins (defaults to 101).
+        num_theta (int): number of poloidal angle bins (defaults to 101).
+        num_levels (int): number of contour regions (defaults to 10).
+    """
+    import read_vmec
+    
+    tor_ext = np.deg2rad(tor_ext)
+    pol_ext = np.deg2rad(pol_ext)
+    
+    coords = extract_coords(source_file)
+    
+    # Load plasma equilibrium data
+    vmec = read_vmec.vmec_data(plas_eq)
+
+    phi_bins = np.linspace(0.0, tor_ext, num = num_phi)
+    theta_bins = np.linspace(-pol_ext/2, pol_ext/2, num = num_theta)
+    
+    # Initialize count matrix
+    count_mat = np.zeros((num_phi, num_theta))
+
+    for pt in coords:
+        # Extract Cartesian coordinates and format as array
+        pt = [pt['x'], pt['y'], pt['z']]
+        pt = np.array(pt)
+        
+        phi, theta = flux_coords(vmec, wall_s, pt)
+        
+        # Shift angles to fit in bins
+        if theta > pol_ext/2:
+            theta = theta - pol_ext
+
+        for i, phi_bin in enumerate(phi_bins):
+            # Conditionally contribute to bin crossing count if crossing within
+            # bin
+            if np.abs(phi - phi_bin) <= tor_ext/(num_phi - 1)/2:
+                for j, theta_bin in enumerate(theta_bins):
+                    # Conditionally contribute to bin crossing count if
+                    # crossing within bin
+                    if np.abs(theta - theta_bin) <= pol_ext/(num_theta - 1)/2:
+                        count_mat[i,j] += 1
+
+    # Define fusion neutron energy (eV)
+    n_energy = 14.1e6
+    # Define eV to joules constant
+    eV2J = 1.60218e-19
+    # Compute total neutron source strength (n/s)
+    strengths = extract_ss(ss_file)
+    SS = sum(strengths)
+    # Define joules to megajoules constant
+    J2MJ = 1e-6
+    # Define number of source particles
+    num_parts = len(coords)
+
+    NWL_mat = count_mat*n_energy*eV2J*SS*J2MJ/num_parts
+
+    plot(NWL_mat, phi_bins, theta_bins, num_levels)

--- a/NWL/NWL.py
+++ b/NWL/NWL.py
@@ -5,9 +5,14 @@ import numpy as np
 export_def = {
     'step_export': True,
     'h5m_export': None,
+    'dir': '',
+    'h5m_filename': 'dagmc',
+    'native_meshing': False,
     'facet_tol': None,
     'len_tol': None,
     'norm_tol': None,
+    'anisotropic_ratio': 100,
+    'deviation_angle': 5,
     'min_mesh_size': 5.0,
     'max_mesh_size': 20.0,
     'volume_atol': 0.00001,
@@ -38,13 +43,6 @@ def NWL_geom(
             }
         export (dict): dictionary of export parameters including
             {
-                'exclude': names of components not to export (list of str,
-                    defaults to empty),
-                'graveyard': generate graveyard volume as additional component
-                    (bool, defaults to False),
-                'dir': directory to which to export output files (str, defaults
-                    to empty string). Note that directory must end in '/', if
-                    using Linux or MacOS, or '\' if using Windows.
                 'step_export': export component STEP files (bool, defaults to
                     True),
                 'h5m_export': export DAGMC-compatible neutronics H5M file using
@@ -52,15 +50,13 @@ def NWL_geom(
                     of 'Cubit' or 'Gmsh' (str, defaults to None). The string is
                     case-sensitive. Note that if magnets are included, 'Cubit'
                     must be used,
+                'dir': directory to which to export output files (str, defaults
+                    to empty string). Note that directory must end in '/', if
+                    using Linux or MacOS, or '\' if using Windows.
                 'h5m_filename': name of DAGMC-compatible neutronics H5M file
                     (str, defaults to 'dagmc'),
-                'plas_h5m_tag': optional alternate material tag to use for
-                    plasma. If none is supplied and the plasma is not excluded,
-                    'plasma' will be used (str, defaults to None),
-                'sol_h5m_tag': optional alternate material tag to use for 
-                    scrape-off layer. If none is supplied and the scrape-off
-                    layer is not excluded, 'sol' will be used (str, defaults to
-                    None),
+                'native_meshing': choose native or legacy faceting for DAGMC
+                    export (bool, defaults to False),
                 'facet_tol': maximum distance a facet may be from surface of
                     CAD representation for Cubit export (float, defaults to
                     None),
@@ -68,6 +64,11 @@ def NWL_geom(
                     (float, defaults to None),
                 'norm_tol': maximum change in angle between normal vector of
                     adjacent facets (float, defaults to None),
+                'anisotropic_ratio': controls edge length ratio of elements
+                    (float, defaults to 100.0),
+                'deviation_angle': controls deviation angle of facet from
+                    surface, i.e. lower deviation angle => more elements in
+                    areas with higher curvature (float, defaults to 5.0),
                 'min_mesh_size': minimum mesh element size for Gmsh export
                     (float, defaults to 5.0),
                 'max_mesh_size': maximum mesh element size for Gmsh export

--- a/NWL/NWL_geom.py
+++ b/NWL/NWL_geom.py
@@ -1,0 +1,33 @@
+import NWL
+import numpy as np
+
+
+# Define first wall geometry parameters
+plas_eq = 'plas_eq.nc'
+wall_s = 1.2
+tor_ext = 90.0
+num_phi = 61
+num_theta = 61
+
+# Define fusion neutron source parameters
+source = {
+    'num_s': 11,
+    'num_theta': 81,
+    'num_phi': 61,
+    'tor_ext': tor_ext
+}
+
+# Define export parameters
+export = {
+    'step_export': True,
+    'h5m_export': 'Cubit',
+    'h5m_filename': 'first_wall',
+    'dir': '',
+    'facet_tol': 1,
+    'len_tol': 5,
+    'norm_tol': None
+}
+
+NWL.NWL_geom(
+    plas_eq, wall_s, tor_ext, num_phi, num_theta, source = source, export = export
+)

--- a/NWL/NWL_geom.py
+++ b/NWL/NWL_geom.py
@@ -1,4 +1,4 @@
-import NWL
+import NWL.NWL as NWL
 import numpy as np
 
 
@@ -23,6 +23,7 @@ export = {
     'h5m_export': 'Cubit',
     'h5m_filename': 'first_wall',
     'dir': '',
+    'native_meshing': False,
     'facet_tol': 1,
     'len_tol': 5,
     'norm_tol': None

--- a/NWL/NWL_geom.py
+++ b/NWL/NWL_geom.py
@@ -30,5 +30,6 @@ export = {
 }
 
 NWL.NWL_geom(
-    plas_eq, wall_s, tor_ext, num_phi, num_theta, source = source, export = export
+    plas_eq, wall_s, tor_ext, num_phi, num_theta, source = source,
+    export = export
 )

--- a/NWL/NWL_plot.py
+++ b/NWL/NWL_plot.py
@@ -1,0 +1,19 @@
+import NWL
+import numpy as np
+
+
+# Define first wall geometry and plotting parameters
+source_file = 'surface_source.h5'
+ss_file = 'strengths.txt'
+plas_eq = 'plas_eq.nc'
+tor_ext = 90.0
+pol_ext = 360.0
+num_phi = 101
+num_theta = 101
+wall_s = 1.2
+num_levels = 10
+
+NWL.NWL_plot(
+    source_file, ss_file, plas_eq, tor_ext, pol_ext, wall_s, num_phi,
+    num_theta, num_levels
+)

--- a/NWL/NWL_plot.py
+++ b/NWL/NWL_plot.py
@@ -1,4 +1,4 @@
-import NWL
+import NWL.NWL as NWL
 import numpy as np
 
 

--- a/NWL/NWL_transport.py
+++ b/NWL/NWL_transport.py
@@ -1,0 +1,11 @@
+import NWL
+
+
+# Define simulation parameters
+dagmc_geom = 'first_wall.h5m'
+source_mesh = 'SourceMesh.h5m'
+tor_ext = 90.0
+ss_file = 'strengths.txt'
+num_parts = 100000
+
+NWL.NWL_transport(dagmc_geom, source_mesh, tor_ext, ss_file, num_parts)

--- a/NWL/NWL_transport.py
+++ b/NWL/NWL_transport.py
@@ -1,4 +1,4 @@
-import NWL
+import NWL.NWL as NWL
 
 
 # Define simulation parameters

--- a/magnet_coils.py
+++ b/magnet_coils.py
@@ -78,55 +78,6 @@ def cut_mags(tor_ext, vol_ids, r_avg):
     return vol_ids
 
 
-def mesh_magnets(vol_ids):
-    """Creates tetrahedral mesh of magnet volumes.
-
-    Arguments:
-        vol_ids (list of int): indices for magnet volumes.
-    """
-    # Loop over magnet indices
-    for vol in vol_ids:
-        # Create scheme and meshes
-        cubit.cmd(f'volume {vol} scheme tetmesh')
-        cubit.cmd(f'mesh volume {vol}')
-
-
-def cut_mags(tor_ext, vol_ids):
-    """Cuts magnet volumes such that only the specified toroidal extent is
-    included.
-    
-    Arguments:
-        tor_ext (float): toroidal extent to model (deg).
-        vol_ids (list of int): indices for magnet volumes.
-    
-    Returns:
-        vol_ids (list of int): updated indices for magnet volumes.
-    """
-    # Create surface
-    cubit.cmd('create surface rectangle width 4000 yplane')
-    # Extract surface index
-    surf_id = cubit.get_last_id("surface")
-    # Move surface
-    cubit.cmd(f'move Surface {surf_id} x 2000')
-    # Sweep surface
-    cubit.cmd(f'sweep surface {surf_id} zaxis angle {tor_ext}')
-    # Extract volume index
-    sweep_id = cubit.get_last_id("volume")
-
-    # Intersect magnet volumes with sweep volume
-    cubit.cmd(
-        'intersect volume ' + ' '.join(str(i) for i in vol_ids)
-        + f' {sweep_id}'
-    )
-
-    # Extract index of most recently created volume
-    last_id = cubit.get_last_id("volume")
-    # Compute magnet volume indices
-    vol_ids = range(sweep_id + 1, last_id + 1)
-
-    return vol_ids
-
-
 def unit_vector(vec):
     """Normalizes given vector.
 

--- a/magnet_coils.py
+++ b/magnet_coils.py
@@ -24,8 +24,8 @@ def mesh_magnets(vol_ids, export_dir, logger):
     logger.info('Exporting coil mesh...')
     
     # Define export paths
-    exo_path = str(Path(export_dir) / 'coil_mesh.exo')
-    h5m_path = str(Path(export_dir) / 'coil_mesh.h5m')
+    exo_path = Path(export_dir) / 'coil_mesh.exo'
+    h5m_path = Path(export_dir) / 'coil_mesh.h5m'
     
     # EXODUS export
     cubit.cmd(f'export mesh "{exo_path}"')
@@ -33,8 +33,8 @@ def mesh_magnets(vol_ids, export_dir, logger):
     # Convert EXODUS to H5M
     mb = core.Core()
     exodus_set = mb.create_meshset()
-    mb.load_file(exo_path, exodus_set)
-    mb.write_file(h5m_path, [exodus_set])
+    mb.load_file(str(exo_path), exodus_set)
+    mb.write_file(str(h5m_path), [exodus_set])
 
 
 def cut_mags(tor_ext, vol_ids, r_avg):
@@ -538,7 +538,7 @@ def magnet_coils(magnets, tor_ext, export_dir, logger = None):
         vol_ids = cut_mags(tor_ext, vol_ids, r_avg)
     
     # Export magnet coils
-    export_path = Path(export_dir) / f'{magnets["name"]}.step'
+    export_path = Path(export_dir) / Path(magnets["name"]).with_suffix('step')
     cubit.cmd(
         f'export step "{export_path}" overwrite'
     )

--- a/magnet_coils.py
+++ b/magnet_coils.py
@@ -78,6 +78,55 @@ def cut_mags(tor_ext, vol_ids, r_avg):
     return vol_ids
 
 
+def mesh_magnets(vol_ids):
+    """Creates tetrahedral mesh of magnet volumes.
+
+    Arguments:
+        vol_ids (list of int): indices for magnet volumes.
+    """
+    # Loop over magnet indices
+    for vol in vol_ids:
+        # Create scheme and meshes
+        cubit.cmd(f'volume {vol} scheme tetmesh')
+        cubit.cmd(f'mesh volume {vol}')
+
+
+def cut_mags(tor_ext, vol_ids):
+    """Cuts magnet volumes such that only the specified toroidal extent is
+    included.
+    
+    Arguments:
+        tor_ext (float): toroidal extent to model (deg).
+        vol_ids (list of int): indices for magnet volumes.
+    
+    Returns:
+        vol_ids (list of int): updated indices for magnet volumes.
+    """
+    # Create surface
+    cubit.cmd('create surface rectangle width 4000 yplane')
+    # Extract surface index
+    surf_id = cubit.get_last_id("surface")
+    # Move surface
+    cubit.cmd(f'move Surface {surf_id} x 2000')
+    # Sweep surface
+    cubit.cmd(f'sweep surface {surf_id} zaxis angle {tor_ext}')
+    # Extract volume index
+    sweep_id = cubit.get_last_id("volume")
+
+    # Intersect magnet volumes with sweep volume
+    cubit.cmd(
+        'intersect volume ' + ' '.join(str(i) for i in vol_ids)
+        + f' {sweep_id}'
+    )
+
+    # Extract index of most recently created volume
+    last_id = cubit.get_last_id("volume")
+    # Compute magnet volume indices
+    vol_ids = range(sweep_id + 1, last_id + 1)
+
+    return vol_ids
+
+
 def unit_vector(vec):
     """Normalizes given vector.
 

--- a/parastell.py
+++ b/parastell.py
@@ -128,7 +128,7 @@ def cubit_export(components, export, magnets):
             norm_tol_str = f'normal_tolerance {norm_tol}'
         
         # DAGMC export
-        export_path = Path(dir) / f'{filename}.h5m'
+        export_path = dir / filename.with_suffix('.h5m')
         cubit.cmd(
             f'export dagmc "{export_path}" {facet_tol_str} {len_tol_str} '
             f'{norm_tol_str} make_watertight'
@@ -195,16 +195,16 @@ def cubit_export(components, export, magnets):
         cubit.cmd("mesh surface all")
 
         # Export DAGMC file
-        export_path = Path(dir) / f'{filename}.h5m'
+        export_path = dir / filename.with_suffix('.h5m')
         cubit.cmd(
             f'export cf_dagmc "{export_path}" overwrite'
         )
 
-    dir = export['dir']
-    filename = export['h5m_filename']
+    dir = Path(export['dir'])
+    filename = Path(export['h5m_filename'])
 
     for name in components.keys():
-        import_path = Path(dir) / f'{name}.step'
+        import_path = dir / Path(name).with_suffix('.step')
         cubit.cmd(f'import step "{import_path}" heal')
         components[name]['vol_id'] = cubit.get_last_id("volume")
 
@@ -309,15 +309,16 @@ def exports(export, components, magnets, logger):
             'Inclusion of magnets in H5M model requires Cubit export'
         )
     
-    dir = export['dir']
-    filename = export['h5m_filename']
+    dir = Path(export['dir'])
+    filename = Path(export['h5m_filename'])
 
     if export['step_export']:
         logger.info('Exporting STEP files...')
         for name, comp in components.items():
+            export_path = dir / Path(name).with_suffix('.step')
             cq.exporters.export(
                 comp['solid'],
-                str(Path(dir) / f'{name}.step')
+                str(export_path)
             )
     
     if export['h5m_export'] == 'Cubit':
@@ -333,7 +334,7 @@ def exports(export, components, magnets, logger):
                 material_tags = [comp['h5m_tag']]
             )
         model.export_dagmc_h5m_file(
-            filename = Path(dir) / f'{filename}.h5m'
+            filename = dir / filename.with_suffix('.h5m')
         )
 
 
@@ -713,7 +714,7 @@ def parastell(
     
     if export_dict['h5m_export'] == 'Cubit' or magnets is not None:
         cubit_dir = os.path.dirname(inspect.getfile(cubit))
-        cubit_dir = cubit_dir + '/plugins/'
+        cubit_dir = Path(cubit_dir) / Path('plugins')
         cubit.init([
             'cubit',
             '-nojournal',
@@ -721,7 +722,7 @@ def parastell(
             '-information', 'off',
             '-warning', 'off',
             '-commandplugindir',
-            cubit_dir
+            str(cubit_dir)
         ])
     
     if logger == None or not logger.hasHandlers():

--- a/parastell.py
+++ b/parastell.py
@@ -28,6 +28,9 @@ def cubit_export(components, export, magnets):
                     defaults to empty),
                 'graveyard': generate graveyard volume as additional component
                     (bool, defaults to False),
+                'dir': directory to which to export output files (str, defaults
+                    to empty string). Note that directory must end in '/', if
+                    using Linux or MacOS, or '\' if using Windows.
                 'step_export': export component STEP files (bool, defaults to
                     True),
                 'h5m_export': export DAGMC-compatible neutronics H5M file using
@@ -35,9 +38,15 @@ def cubit_export(components, export, magnets):
                     of 'Cubit' or 'Gmsh' (str, defaults to None). The string is
                     case-sensitive. Note that if magnets are included, 'Cubit'
                     must be used,
+                'h5m_filename': name of DAGMC-compatible neutronics H5M file
+                    (str, defaults to 'dagmc'),
                 'plas_h5m_tag': optional alternate material tag to use for
                     plasma. If none is supplied and the plasma is not excluded,
                     'plasma' will be used (str, defaults to None),
+                'sol_h5m_tag': optional alternate material tag to use for 
+                    scrape-off layer. If none is supplied and the scrape-off
+                    layer is not excluded, 'sol' will be used (str, defaults to
+                    None),
                 'facet_tol': maximum distance a facet may be from surface of
                     CAD representation for Cubit export (float, defaults to
                     None),
@@ -211,6 +220,9 @@ def exports(export, components, magnets, logger):
                     defaults to empty),
                 'graveyard': generate graveyard volume as additional component
                     (bool, defaults to False),
+                'dir': directory to which to export output files (str, defaults
+                    to empty string). Note that directory must end in '/', if
+                    using Linux or MacOS, or '\' if using Windows.
                 'step_export': export component STEP files (bool, defaults to
                     True),
                 'h5m_export': export DAGMC-compatible neutronics H5M file using
@@ -218,9 +230,15 @@ def exports(export, components, magnets, logger):
                     of 'Cubit' or 'Gmsh' (str, defaults to None). The string is
                     case-sensitive. Note that if magnets are included, 'Cubit'
                     must be used,
+                'h5m_filename': name of DAGMC-compatible neutronics H5M file
+                    (str, defaults to 'dagmc'),
                 'plas_h5m_tag': optional alternate material tag to use for
                     plasma. If none is supplied and the plasma is not excluded,
                     'plasma' will be used (str, defaults to None),
+                'sol_h5m_tag': optional alternate material tag to use for 
+                    scrape-off layer. If none is supplied and the scrape-off
+                    layer is not excluded, 'sol' will be used (str, defaults to
+                    None),
                 'facet_tol': maximum distance a facet may be from surface of
                     CAD representation for Cubit export (float, defaults to
                     None),
@@ -294,7 +312,9 @@ def exports(export, components, magnets, logger):
                 comp['solid'],
                 material_tags = [comp['h5m_tag']]
             )
-        model.export_dagmc_h5m_file()
+        model.export_dagmc_h5m_file(
+            filename = f"{export['dir']}{export['h5m_filename']}.h5m"
+        )
 
 
 def graveyard(vmec, offset, components, logger):
@@ -349,7 +369,7 @@ def surf_norm(vmec, s, phi, theta, ref_pt, plane_norm):
 
     Arguments:
         vmec (object): plasma equilibrium object.
-        s (float): normalized magnetic closed flux surface value.
+        s (float): normalized magnetic closed flux surface label.
         phi (float): toroidal angle being solved for (rad).
         theta (float): poloidal angle of interest (rad).
         ref_pt (array of float): Cartesian coordinates of plasma edge or
@@ -377,7 +397,7 @@ def offset_point(vmec, s, theta, phi, offset, plane_norm):
 
     Arguments:
         vmec (object): plasma equilibrium object.
-        s (float): normalized magnetic closed flux surface value.
+        s (float): normalized magnetic closed flux surface label.
         theta (float): poloidal angle of interest (rad).
         phi (float): toroidal angle of interest (rad).
         offset (float): total offset of layer from plamsa (m).
@@ -410,7 +430,7 @@ def stellarator_torus(
     
     Arguments:
         vmec (object): plasma equilibrium object.
-        s (float): normalized magnetic closed flux surface value.
+        s (float): normalized magnetic closed flux surface label.
         tor_ext (float): toroidal extent of build (rad).
         repeat (int): number of times to repeat build.
         phi_list_exp (list of float): interpolated list of toroidal angles
@@ -517,11 +537,12 @@ def expand_ang(ang_list, num_ang):
 
 # Define default export dictionary
 export_def = {
-    'dir': '',
     'exclude': [],
     'graveyard': False,
     'step_export': True,
     'h5m_export': None,
+    'dir': '',
+    'dagmc_filename': 'dagmc',
     'plas_h5m_tag': None,
     'sol_h5m_tag': None,
     'facet_tol': None,
@@ -565,7 +586,8 @@ def parastell(
                 'theta_list': poloidal angles at which radial build is
                     specified. This list should always span 360 degrees (list
                     of float, deg).
-                'wall_s': closed flux index extrapolation at wall (float),
+                'wall_s': closed flux surface label extrapolation at wall
+                    (float),
                 'radial_build': {
                     'component': {
                         'thickness_matrix': list of list of float (cm),
@@ -579,7 +601,7 @@ def parastell(
         num_phi (int): number of phi geometric cross-sections to make for each
             build segment (defaults to 61).
         num_theta (int): number of points defining the geometric cross-section
-            (defaults to 100).
+            (defaults to 61).
         magnets (dict): dictionary of magnet parameters including
             {
                 'file': path to magnet coil point-locus data file (str),
@@ -612,6 +634,9 @@ def parastell(
                     defaults to empty),
                 'graveyard': generate graveyard volume as additional component
                     (bool, defaults to False),
+                'dir': directory to which to export output files (str, defaults
+                    to empty string). Note that directory must end in '/', if
+                    using Linux or MacOS, or '\' if using Windows.
                 'step_export': export component STEP files (bool, defaults to
                     True),
                 'h5m_export': export DAGMC-compatible neutronics H5M file using
@@ -619,6 +644,8 @@ def parastell(
                     of 'Cubit' or 'Gmsh' (str, defaults to None). The string is
                     case-sensitive. Note that if magnets are included, 'Cubit'
                     must be used,
+                'h5m_filename': name of DAGMC-compatible neutronics H5M file
+                    (str, defaults to 'dagmc'),
                 'plas_h5m_tag': optional alternate material tag to use for
                     plasma. If none is supplied and the plasma is not excluded,
                     'plasma' will be used (str, defaults to None),

--- a/parastell.py
+++ b/parastell.py
@@ -126,18 +126,18 @@ def cubit_export(components, export, magnets):
     def native_export():
         """Exports neutronics H5M file via native Cubit faceting method.
         """
-        #extract Cubit export parameters
+        # Extract Cubit export parameters
         anisotropic_ratio = export['anisotropic_ratio']
         deviation_angle = export['deviation_angle']
 
-        # create materials for native cubit meshing
+        # Create materials for native cubit meshing
         for comp in components.values():
             cubit.cmd(
                 f'create material "{comp["h5m_tag"]}" property_group '
                 + '"CUBIT-ABAQUS"'
             )
 
-        # assign components to blocks
+        # Assign components to blocks
         for comp in components.values():
             cubit.cmd('set duplicate block elements off')
             cubit.cmd(
@@ -145,7 +145,7 @@ def cubit_export(components, export, magnets):
                 + str(comp['vol_id'])
             )
         
-        # assign materials to blocks
+        # Assign materials to blocks
         for comp in components.values():
             cubit.cmd(
                 "block " + str(comp['vol_id']) + " material "
@@ -186,15 +186,12 @@ def cubit_export(components, export, magnets):
         # Export DAGMC file
         cubit.cmd(f'export cf_dagmc "{cwd + "/dagmc.h5m"}" overwrite')
 
-    # Get current working directory
     cwd = os.getcwd()
 
-    # Import solids
     for name in components.keys():
         cubit.cmd(f'import step "' + cwd + '/' + name + '.step" heal')
         components[name]['vol_id'] = cubit.get_last_id("volume")
 
-    # Imprint and merge all volumes
     cubit.cmd('imprint volume all')
     cubit.cmd('merge volume all')
 

--- a/source_mesh.py
+++ b/source_mesh.py
@@ -1,6 +1,7 @@
 import log
 from pymoab import core, types
 import numpy as np
+from pathlib import Path
 
 
 def rxn_rate(s):
@@ -406,7 +407,7 @@ def create_mbc():
     return mbc, tag_handle
 
 
-def source_mesh(vmec, source, logger = None):
+def source_mesh(vmec, source, export_dir, logger = None):
     """Creates H5M volumetric mesh defining fusion source using PyMOAB and
     user-supplied plasma equilibrium VMEC data.
 
@@ -420,6 +421,7 @@ def source_mesh(vmec, source, logger = None):
                 'num_phi': number of toroidal angles defining mesh (int),
                 'tor_ext': toroidal extent to model (float, deg)
             }
+        export_dir (str): directory to which to export output files.
         logger (object): logger object (defaults to None). If no logger is
             supplied, a default logger will be instantiated.
 
@@ -452,6 +454,7 @@ def source_mesh(vmec, source, logger = None):
         verts_s
     )
 
-    mbc.write_file("SourceMesh.h5m")
+    export_path = str(Path(export_dir) / 'SourceMesh.h5m')
+    mbc.write_file(export_path)
 
     return strengths

--- a/source_mesh.py
+++ b/source_mesh.py
@@ -454,7 +454,7 @@ def source_mesh(vmec, source, export_dir, logger = None):
         verts_s
     )
 
-    export_path = str(Path(export_dir) / 'SourceMesh.h5m')
-    mbc.write_file(export_path)
+    export_path = Path(export_dir) / 'SourceMesh.h5m'
+    mbc.write_file(str(export_path))
 
     return strengths


### PR DESCRIPTION
Adds a script to compute NWL and create all corresponding geometry, source, etc. For now, this functionality is included in a separate directory but this organization is free to change. Note that there are three primary functionalities in the main script `NWL.py`, reflected by the three new example scripts `NWL_geom.py`, `NWL_transport.py`, and `NWL_plot.py`. We should discuss this structure but it is primarily due to the (not strict) necessity of separate `conda` environments for ParaStell and OpenMC. Cubit (a dependency of ParaStell) is built with an HDF5 version that does not play well with `conda` environments containing OpenMC. Perhaps there is some solution we can figure out that would remedy this issue.

Fixes #22 