### PR TITLE
added cubit reset

### DIFF
--- a/parastell.py
+++ b/parastell.py
@@ -861,3 +861,6 @@ def parastell(
             vmec, source, export['dir'], logger = logger
         )
         return strengths
+    
+    # reset cubit to avoid issues when looping
+    cubit.cmd('reset')

--- a/parastell.py
+++ b/parastell.py
@@ -847,7 +847,7 @@ def parastell(
 
     if magnets is not None:
         magnets['vol_id'] = magnet_coils.magnet_coils(
-            magnets, (repeat + 1)*tor_ext, export['dir'], logger = logger
+            magnets, (repeat + 1)*tor_ext, export_dict['dir'], logger = logger
         )
 
     try:
@@ -858,9 +858,10 @@ def parastell(
     
     if source is not None:
         strengths = source_mesh.source_mesh(
-            vmec, source, export['dir'], logger = logger
+            vmec, source, export_dict['dir'], logger = logger
         )
         return strengths
     
     # reset cubit to avoid issues when looping
-    cubit.cmd('reset')
+    if export_dict['h5m_export'] == 'Cubit':    
+        cubit.cmd('reset')


### PR DESCRIPTION

Looping Parastell to Make Different Geometry Results in All Previous Geometry Being Included in Each Model

Examples:
First iteration
![image](https://github.com/svalinn/parastell/assets/84034227/36822d8e-5b57-41e3-bcab-6c22dd2fa2f0)
9 layers visible (excluding plasma)
Second iteration
![image](https://github.com/svalinn/parastell/assets/84034227/9d48857c-a298-4c72-b4e0-2751a7ff7af9)
The only difference between these two should be the thickness of the layers, but it can be seen that there are many more layers due to both sets of step files existing in cubit at the time of the export.

Adding `cubit.cmd('reset')` at the very end of `parastell.parastell` resolves this, I put it here rather than in the `cubit_export` in case some other cubit operations ever need to take place after `cubit_export`. As always, open to suggestions

