### PR TITLE
Add dockerfile

### DIFF
--- a/dockerfile
+++ b/dockerfile
@@ -1,7 +1,7 @@
 FROM continuumio/miniconda3
 
 ENV TZ=America/Chicago
-ENV PYTHONPATH=/opt/Coreform-Cubit-2024.3/bin/
+ENV PYTHONPATH=/opt/Coreform-Cubit-2023.11/bin/
 ENV PYTHONPATH=$PYTHONPATH:/opt/pystell_uw
 ENV PYTHONPATH=$PYTHONPATH:/opt/parastell
 RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
@@ -34,7 +34,7 @@ RUN apt-get install -y libgl1-mesa-glx \
                         libxinerama1
 
 # download cubit
-RUN wget -O /cubit.deb https://f002.backblazeb2.com/file/cubit-downloads/Coreform-Cubit/Releases/Linux/Coreform-Cubit-2024.3%2B46968-Lin64.deb
+RUN wget -O /cubit.deb https://f002.backblazeb2.com/file/cubit-downloads/Coreform-Cubit/Releases/Linux/Coreform-Cubit-2023.11%2B43088-Lin64.deb
 
 # install cubit
 RUN dpkg -i cubit.deb

--- a/dockerfile
+++ b/dockerfile
@@ -1,0 +1,42 @@
+FROM continuumio/miniconda3
+
+ENV TZ=America/Chicago
+ENV PYTHONPATH=/opt/Coreform-Cubit-2024.3/bin/
+RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
+
+RUN apt-get update -y
+RUN apt-get upgrade -y
+
+RUN apt-get install -y libgl1-mesa-glx \
+                       libgl1-mesa-dev \
+                       libglu1-mesa-dev \
+                       freeglut3-dev \
+                       libosmesa6 \
+                       libosmesa6-dev \
+                       libgles2-mesa-dev \
+                       curl \
+                       wget \
+                       libxm4 
+RUN apt-get clean
+
+# download cubit
+RUN wget -O /cubit.deb https://f002.backblazeb2.com/file/cubit-downloads/Coreform-Cubit/Releases/Linux/Coreform-Cubit-2024.3%2B46968-Lin64.deb
+
+
+# install dependencies
+RUN apt-get install -y libx11-6 
+RUN apt-get install -y libxt6 
+RUN apt-get install -y libgl1
+RUN apt-get install -y libglu1-mesa
+RUN apt-get install -y libgl1-mesa-glx
+RUN apt-get install -y libxcb-icccm4 
+RUN apt-get install -y libxcb-image0 
+RUN apt-get install -y libxcb-keysyms1 
+RUN apt-get install -y libxcb-render-util0 
+RUN apt-get install -y libxkbcommon-x11-0 
+RUN apt-get install -y libxcb-randr0 
+RUN apt-get install -y libxcb-xinerama0
+
+# install cubit
+RUN dpkg -i cubit.deb
+

--- a/dockerfile
+++ b/dockerfile
@@ -1,9 +1,6 @@
 FROM continuumio/miniconda3
 
 ENV TZ=America/Chicago
-ENV PYTHONPATH=/opt/Coreform-Cubit-2023.11/bin/
-ENV PYTHONPATH=$PYTHONPATH:/opt/pystell_uw
-ENV PYTHONPATH=$PYTHONPATH:/opt/parastell
 RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
 RUN apt-get update -y
 RUN apt-get upgrade -y
@@ -38,17 +35,22 @@ RUN wget -O /cubit.deb https://f002.backblazeb2.com/file/cubit-downloads/Corefor
 
 # install cubit
 RUN dpkg -i cubit.deb
+ENV PYTHONPATH=/opt/Coreform-Cubit-2023.11/bin/
 
 # parastell env
 COPY ./environment.yml /environment.yml
-
 RUN conda env create -f environment.yml
+RUN echo "source activate parastell_env" >> ~/.bashrc
 
 WORKDIR /opt
 
+# install pystell_uw
 RUN git clone https://github.com/aaroncbader/pystell_uw.git
+ENV PYTHONPATH=$PYTHONPATH:/opt/pystell_uw
 
+# install parastell
 RUN git clone https://github.com/svalinn/parastell.git
+ENV PYTHONPATH=$PYTHONPATH:/opt/parastell
 
 WORKDIR /
 

--- a/dockerfile
+++ b/dockerfile
@@ -40,9 +40,9 @@ RUN wget -O /cubit.deb https://f002.backblazeb2.com/file/cubit-downloads/Corefor
 RUN dpkg -i cubit.deb
 
 # parastell env
-COPY ./parastell_env.yml /parastell_env.yml
+COPY ./environment.yml /environment.yml
 
-RUN conda env create -f parastell_env.yml
+RUN conda env create -f environment.yml
 
 WORKDIR /opt
 

--- a/dockerfile
+++ b/dockerfile
@@ -2,8 +2,9 @@ FROM continuumio/miniconda3
 
 ENV TZ=America/Chicago
 ENV PYTHONPATH=/opt/Coreform-Cubit-2024.3/bin/
+ENV PYTHONPATH=$PYTHONPATH:/opt/pystell_uw
+ENV PYTHONPATH=$PYTHONPATH:/opt/parastell
 RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
-
 RUN apt-get update -y
 RUN apt-get upgrade -y
 
@@ -27,11 +28,27 @@ RUN apt-get install -y libgl1-mesa-glx \
                         libxkbcommon-x11-0 \
                         libxcb-randr0 \
                         libxcb-xinerama0 \
-                        libxm4
+                        libxm4 \
+                        libtiff5 \
+                        libxcursor1 \
+                        libxinerama1
 
 # download cubit
 RUN wget -O /cubit.deb https://f002.backblazeb2.com/file/cubit-downloads/Coreform-Cubit/Releases/Linux/Coreform-Cubit-2024.3%2B46968-Lin64.deb
 
 # install cubit
 RUN dpkg -i cubit.deb
+
+# parastell env
+COPY ./parastell_env.yml /parastell_env.yml
+
+RUN conda env create -f parastell_env.yml
+
+WORKDIR /opt
+
+RUN git clone https://github.com/aaroncbader/pystell_uw.git
+
+RUN git clone https://github.com/svalinn/parastell.git
+
+WORKDIR /
 

--- a/dockerfile
+++ b/dockerfile
@@ -7,35 +7,30 @@ RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
 RUN apt-get update -y
 RUN apt-get upgrade -y
 
+# install dependencies
 RUN apt-get install -y libgl1-mesa-glx \
-                       libgl1-mesa-dev \
-                       libglu1-mesa-dev \
-                       freeglut3-dev \
-                       libosmesa6 \
-                       libosmesa6-dev \
-                       libgles2-mesa-dev \
-                       curl \
-                       wget \
-                       libxm4 
-RUN apt-get clean
+                        libgl1-mesa-dev \
+                        libglu1-mesa-dev \
+                        freeglut3-dev \
+                        libosmesa6 \
+                        libosmesa6-dev \
+                        libgles2-mesa-dev \
+                        curl \
+                        wget \
+                        libx11-6 \
+                        libxt6 \
+                        libgl1 \
+                        libxcb-icccm4 \
+                        libxcb-image0 \
+                        libxcb-keysyms1 \
+                        libxcb-render-util0 \
+                        libxkbcommon-x11-0 \
+                        libxcb-randr0 \
+                        libxcb-xinerama0 \
+                        libxm4
 
 # download cubit
 RUN wget -O /cubit.deb https://f002.backblazeb2.com/file/cubit-downloads/Coreform-Cubit/Releases/Linux/Coreform-Cubit-2024.3%2B46968-Lin64.deb
-
-
-# install dependencies
-RUN apt-get install -y libx11-6 
-RUN apt-get install -y libxt6 
-RUN apt-get install -y libgl1
-RUN apt-get install -y libglu1-mesa
-RUN apt-get install -y libgl1-mesa-glx
-RUN apt-get install -y libxcb-icccm4 
-RUN apt-get install -y libxcb-image0 
-RUN apt-get install -y libxcb-keysyms1 
-RUN apt-get install -y libxcb-render-util0 
-RUN apt-get install -y libxkbcommon-x11-0 
-RUN apt-get install -y libxcb-randr0 
-RUN apt-get install -y libxcb-xinerama0
 
 # install cubit
 RUN dpkg -i cubit.deb

--- a/environment.yml
+++ b/environment.yml
@@ -17,3 +17,4 @@ dependencies:
   - pip:
       - netcdf4
       - pyyaml
+      - pytest


### PR DESCRIPTION
Heavily inspired by a dockerfile shared by Shimwell here https://forum.coreform.com/t/trelis-in-docker/442/2.

Uses the miniconda docker image as the base (Debian Bullseye), found here https://hub.docker.com/r/continuumio/miniconda3. To use cubit, the image can be run interactively, and the license file copied to the appropriate location. Cubit works in terminal with the --no-graphics option and can be imported into python. 

I expect it will need a couple additions for this to work with Github actions. I'll start looking at that documentation in the next few days, in the meantime wanted to get this posted to get some eyes on it sooner rather than later

fixes #57 