### PR TITLE
Some final input on the IVC OO update

### DIFF
--- a/src/cubit_io.py
+++ b/src/cubit_io.py
@@ -10,6 +10,8 @@ initialized = False
 def init_cubit():
     """Initializes Coreform Cubit with the DAGMC plugin.
     """
+    global initialized
+    
     if not initialized:
         cubit_plugin_dir = (
             Path(os.path.dirname(inspect.getfile(cubit))) / Path('plugins')

--- a/src/cubit_io.py
+++ b/src/cubit_io.py
@@ -4,19 +4,12 @@ import os
 import inspect
 import subprocess
 
+initialized = False
 
-def init_cubit(cubit_initialized=False):
+def init_cubit():
     """Initializes Coreform Cubit with the DAGMC plugin.
-
-    Arguments:
-        cubit_initialized (bool): flag to indicate whether Coreform Cubit has
-            been initialized.
-
-    Returns:
-        cubit_initialized (bool): flag to indicate whether Coreform Cubit has
-            been initialized.
     """
-    if not cubit_initialized:
+    if not initialized:
         cubit_plugin_dir = (
             Path(os.path.dirname(inspect.getfile(cubit))) / Path('plugins')
         )
@@ -29,9 +22,7 @@ def init_cubit(cubit_initialized=False):
             '-commandplugindir',
             str(cubit_plugin_dir)
         ])
-        cubit_initialized = True
-
-    return cubit_initialized
+        initialized = True
 
 
 def import_step_cubit(filename, import_dir):
@@ -61,6 +52,8 @@ def export_step_cubit(filename, export_dir=''):
         export_dir (str): directory to which to export the STEP output file
             (defaults to empty string).
     """
+    init_cubit()
+
     export_path = Path(export_dir) / Path(filename).with_suffix('.step')
     cubit.cmd(f'export step "{export_path}" overwrite')
 
@@ -74,6 +67,8 @@ def export_mesh_cubit(filename, export_dir=''):
         export_dir (str): directory to which to export the H5M output file
             (defaults to empty string).
     """
+    init_cubit()
+    
     exo_path = Path(export_dir) / Path(filename).with_suffix('.exo')
     h5m_path = Path(export_dir) / Path(filename).with_suffix('.h5m')
 
@@ -101,6 +96,8 @@ def export_dagmc_cubit_legacy(
         export_dir (str): directory to which to export the DAGMC output file
             (defaults to empty string).
     """
+    init_cubit()
+    
     tol_str = ''
 
     if faceting_tolerance is not None:
@@ -134,6 +131,8 @@ def export_dagmc_cubit_native(
         export_dir (str): directory to which to export the DAGMC output file
             (defaults to empty string).
     """
+    init_cubit()
+    
     cubit.cmd(
         f'set trimesher coarse on ratio {anisotropic_ratio} '
         f'angle {deviation_angle}'

--- a/src/cubit_io.py
+++ b/src/cubit_io.py
@@ -1,8 +1,9 @@
-import cubit
 from pathlib import Path
 import os
 import inspect
 import subprocess
+
+import cubit
 
 initialized = False
 

--- a/src/invessel_build.py
+++ b/src/invessel_build.py
@@ -176,13 +176,12 @@ class InVesselBuild(object):
         self.Surfaces = []
         self.Components = []
 
-        try:
-            assert (self.repeat + 1) * self.toroidal_angles[-1] <= 360.0, (
+        if (self.repeat + 1) * self.toroidal_angles[-1] > 360.0:
+            e = AssertionError(
                 'Total toroidal extent requested with repeated geometry '
                 'exceeds 360 degrees. Please examine phi_list and the repeat '
                 'parameter.'
             )
-        except AssertionError as e:
             self.logger.error(e.args[0])
             raise e
 
@@ -253,12 +252,11 @@ class InVesselBuild(object):
         ))
 
         for name, layer_data in self.radial_build.items():
-            try:
-                assert np.all(np.array(layer_data['thickness_matrix']) >= 0), (
+            if np.any(np.array(layer_data['thickness_matrix']) < 0):
+                e = AssertionError(
                     'Component thicknesses must be greater than or equal to 0. '
                     'Check thickness inputs for negative values.'
                 )
-            except AssertionError as e:
                 self.logger.error(e.args[0])
                 raise e
 

--- a/src/invessel_build.py
+++ b/src/invessel_build.py
@@ -1,15 +1,17 @@
+import log
+import argparse
+import yaml
+from pathlib import Path
+
+import numpy as np
+from scipy.interpolate import RegularGridInterpolator
+
 import cubit
 import cadquery as cq
 import cad_to_dagmc
 import read_vmec
-from src.utils import expand_ang_list, normalize, m2cm, invessel_build_def
-import log
-import numpy as np
-from scipy.interpolate import RegularGridInterpolator
-from pathlib import Path
-import argparse
-import yaml
 
+from src.utils import expand_ang_list, normalize, m2cm, invessel_build_def
 
 def orient_spline_surfaces(volume_id):
     """Extracts the inner and outer surface IDs for a given ParaStell in-vessel
@@ -22,6 +24,7 @@ def orient_spline_surfaces(volume_id):
         inner_surface_id (int): Cubit ID of in-vessel component inner surface.
         outer_surface_id (int): Cubit ID of in-vessel component outer surface.
     """
+    
     surfaces = cubit.get_relatives('volume', volume_id, 'surface')
 
     spline_surfaces = []

--- a/src/invessel_build.py
+++ b/src/invessel_build.py
@@ -2,15 +2,13 @@ import cubit
 import cadquery as cq
 import cad_to_dagmc
 import read_vmec
-from src.utils import expand_ang_list, normalize, def_default_params
+from src.utils import expand_ang_list, normalize, m2cm, invessel_build_def
 import log
 import numpy as np
 from scipy.interpolate import RegularGridInterpolator
 from pathlib import Path
 import argparse
 import yaml
-
-m2cm, _, invessel_build_def, _, _, _ = def_default_params()
 
 
 def orient_spline_surfaces(volume_id):

--- a/src/magnet_coils.py
+++ b/src/magnet_coils.py
@@ -4,10 +4,7 @@ import log
 import numpy as np
 import yaml
 import argparse
-from src.utils import normalize, def_default_params
-
-m2cm, _, _, magnets_def, _, _ = def_default_params()
-
+from src.utils import normalize, m2cm, magnets_def
 
 class MagnetSet(object):
     """An object representing a set of modular stellarator magnet coils.

--- a/src/magnet_coils.py
+++ b/src/magnet_coils.py
@@ -5,7 +5,7 @@ import argparse
 import numpy as np
 
 import cubit
-from src.cubit_io import init_cubit, export_step_cubit, export_mesh_cubit
+import src.cubit_io as cubit_io 
 from src.utils import normalize, m2cm, magnets_def
 
 class MagnetSet(object):
@@ -28,8 +28,6 @@ class MagnetSet(object):
             neutronics model (defaults to 'magnets').
         logger (object): logger object (defaults to None). If no logger is
             supplied, a default logger will be instantiated.
-        cubit_initialized (bool): flag to indicate whether Coreform Cubit has
-            been initialized (defaults to False).
     """
 
     def __init__(
@@ -42,7 +40,6 @@ class MagnetSet(object):
         scale=m2cm,
         mat_tag=None,
         logger=None,
-        cubit_initialized=False
     ):
         self.coils_file_path = coils_file_path
         self.cross_section = cross_section
@@ -57,7 +54,7 @@ class MagnetSet(object):
         else:
             self.logger = logger
 
-        self.cubit_initialized = init_cubit(cubit_initialized)
+        cubit_io.init_cubit()
 
         self._extract_filaments()
         self._extract_cross_section()
@@ -339,7 +336,7 @@ class MagnetSet(object):
         self.logger.info('Exporting STEP file for magnet coils...')
 
         self.step_filename = filename
-        export_step_cubit(filename=filename, export_dir=export_dir)
+        cubit_io.export_step_cubit(filename=filename, export_dir=export_dir)
 
     def mesh_magnets(self):
         """Creates tetrahedral mesh of magnet volumes via Coreform Cubit.
@@ -361,7 +358,7 @@ class MagnetSet(object):
         """
         self.logger.info('Exporting mesh H5M file for magnet coils...')
         
-        export_mesh_cubit(filename=filename, export_dir=export_dir)
+        cubit_io.export_mesh_cubit(filename=filename, export_dir=export_dir)
 
 
 class MagnetCoil(object):

--- a/src/magnet_coils.py
+++ b/src/magnet_coils.py
@@ -1,9 +1,11 @@
-import cubit
-from src.cubit_io import init_cubit, export_step_cubit, export_mesh_cubit
 import log
-import numpy as np
 import yaml
 import argparse
+
+import numpy as np
+
+import cubit
+from src.cubit_io import init_cubit, export_step_cubit, export_mesh_cubit
 from src.utils import normalize, m2cm, magnets_def
 
 class MagnetSet(object):

--- a/src/parastell.py
+++ b/src/parastell.py
@@ -45,11 +45,11 @@ class Stellarator(object):
         self.magnet_set = None
         self.source_mesh = None
 
-    def construct_invessel_build(self, invessel_build):
+    def construct_invessel_build(self, ivb_dict):
         """Construct InVesselBuild class object.
 
         Arguments:
-            invessel_build (dict): dictionary of in-vessel component
+            ivb_dict (dict): dictionary of in-vessel component
                 parameters, including
                 {
                     'toroidal_angles': toroidal angles at which radial build is
@@ -110,8 +110,6 @@ class Stellarator(object):
                         (str, defaults to empty string).
                 }
         """
-        ivb_dict = invessel_build_def.copy()
-        ivb_dict.update(invessel_build)
 
         self.invessel_build = ivb.InVesselBuild(
             self.vmec, ivb_dict['toroidal_angles'],
@@ -125,13 +123,6 @@ class Stellarator(object):
         self.invessel_build.populate_surfaces()
         self.invessel_build.calculate_loci()
         self.invessel_build.generate_components()
-        self.invessel_build.export_step(export_dir=ivb_dict['export_dir'])
-
-        if ivb_dict['export_cad_to_dagmc']:
-            self.invessel_build.export_cad_to_dagmc(
-                filename=ivb_dict['dagmc_filename'],
-                export_dir=ivb_dict['export_dir']
-            )
 
     def construct_magnets(self, magnets):
         """Constructs MagnetSet class object.
@@ -412,7 +403,19 @@ def parastell():
     ) = read_yaml_config(args.filename)
 
     stellarator = Stellarator(vmec_file)
-    stellarator.construct_invessel_build(invessel_build)
+
+    ivb_dict = invessel_build_def.copy()
+    ivb_dict.update(invessel_build)
+
+    stellarator.construct_invessel_build(ivb_dict)
+    stellarator.invessel_build.export_step(export_dir=ivb_dict['export_dir'])
+
+    if ivb_dict['export_cad_to_dagmc']:
+        stellarator.invessel_build.export_cad_to_dagmc(
+            filename=ivb_dict['dagmc_filename'],
+            export_dir=ivb_dict['export_dir']
+        )
+
     stellarator.construct_magnets(magnets)
     stellarator.construct_source_mesh(source)
     stellarator.export_dagmc(dagmc_export)

--- a/src/parastell.py
+++ b/src/parastell.py
@@ -125,7 +125,12 @@ class Stellarator(object):
         self.invessel_build.generate_components()
 
     def export_invessel_build(self, ivb_dict):
+        """Export Invessel Build components
 
+        Arguments:
+            ivb_dict (dict): dictionary of in-vessel component
+                parameters - see construct_invessel_build()
+        """
         self.invessel_build.export_step(export_dir=ivb_dict['export_dir'])
 
         if ivb_dict['export_cad_to_dagmc']:
@@ -181,6 +186,12 @@ class Stellarator(object):
         self.magnet_set.build_magnet_coils()
 
     def export_magnets(self, magnets_dict):
+        """Export magnet components
+
+        Arguments:
+            magnets_dict (dict): dictionary of magnet component
+                parameters - see construct_magnets()
+        """
 
         self.magnet_set.export_step(
             filename=magnets_dict['step_filename'],
@@ -227,6 +238,12 @@ class Stellarator(object):
         self.source_mesh.create_mesh()
 
     def export_source_mesh(self, source_dict):
+        """Export source mesh
+
+        Arguments:
+            source_dict (dict): dictionary of source mesh parameters
+                see construct_source_mesh()
+        """
 
         self.source_mesh.export_mesh(
             filename=source_dict['filename'],

--- a/src/parastell.py
+++ b/src/parastell.py
@@ -296,7 +296,7 @@ class Stellarator(object):
         if self.invessel_build:
             for data in self.invessel_build.radial_build.values():
                 cubit.cmd(
-                    f'group "mat:{data['mat_tag']}" add volume {data['vol_id']}'
+                    f'group "mat:{data["mat_tag"]}" add volume {data["vol_id"]}'
                 )
 
     def _tag_materials_native(self):

--- a/src/parastell.py
+++ b/src/parastell.py
@@ -254,11 +254,9 @@ class Stellarator(object):
         """Imports STEP files from in-vessel build into Coreform Cubit.
         (Internal function not intended to be called externally)
         """
-        for component, data in (
-            self.invessel_build.radial_build.items()
-        ):
+        for name, data in self.invessel_build.radial_build.items():
             vol_id = cubit_io.import_step_cubit(
-                component, self.invessel_build.export_dir
+                name, self.invessel_build.export_dir
             )
             data['vol_id'] = vol_id
 
@@ -275,12 +273,12 @@ class Stellarator(object):
             self.components[name]['vol_id'] = list(self.magnet_set.volume_ids)
 
         if self.invessel_build is not None:
-            for component, data in (
+            for name, data in (
                 self.invessel_build.radial_build.items()
             ):
-                self.components[component] = {}
-                self.components[component]['mat_tag'] = data['mat_tag']
-                self.components[component]['vol_id'] = data['vol_id']
+                self.components[name] = {}
+                self.components[name]['mat_tag'] = data['mat_tag']
+                self.components[name]['vol_id'] = data['vol_id']
 
     def _tag_materials_legacy(self):
         """Applies material tags to corresponding CAD volumes for legacy DAGMC
@@ -444,6 +442,7 @@ def parastell():
     magnets_dict.update(magnets)
 
     stellarator.construct_magnets(magnets)
+    stellarator.export_magnets(magnets)
 
     # Source Mesh
     source_dict = source_def.copy()

--- a/src/parastell.py
+++ b/src/parastell.py
@@ -1,4 +1,10 @@
+import log
+import argparse
+import yaml
+
 import cubit
+import read_vmec
+
 from src.cubit_io import (
     init_cubit, import_step_cubit, export_dagmc_cubit_legacy,
     export_dagmc_cubit_native
@@ -8,10 +14,6 @@ import src.magnet_coils as mc
 import src.source_mesh as sm
 from src.utils import invessel_build_def, magnets_def, source_def,
     dagmc_export_def
-import log
-import read_vmec
-import argparse
-import yaml
 
 class Stellarator(object):
     """Parametrically generates a fusion stellarator reactor core model using

--- a/src/parastell.py
+++ b/src/parastell.py
@@ -9,8 +9,8 @@ import src.invessel_build as ivb
 import src.magnet_coils as mc
 import src.source_mesh as sm
 import src.cubit_io as cubit_io
-from src.utils import invessel_build_def, magnets_def, source_def,
-    dagmc_export_def
+from src.utils import ( invessel_build_def, magnets_def, source_def,
+    dagmc_export_def )
 
 
 def make_material_block(mat_tag, block_id, vol_id_str):

--- a/src/parastell.py
+++ b/src/parastell.py
@@ -124,11 +124,21 @@ class Stellarator(object):
         self.invessel_build.calculate_loci()
         self.invessel_build.generate_components()
 
-    def construct_magnets(self, magnets):
+    def export_invessel_build(self, ivb_dict):
+
+        self.invessel_build.export_step(export_dir=ivb_dict['export_dir'])
+
+        if ivb_dict['export_cad_to_dagmc']:
+            self.invessel_build.export_cad_to_dagmc(
+                filename=ivb_dict['dagmc_filename'],
+                export_dir=ivb_dict['export_dir']
+            )
+
+    def construct_magnets(self, magnets_dict):
         """Constructs MagnetSet class object.
 
         Arguments:
-            magnets (dict): dictionary of magnet parameters, including
+            magnets_dict (dict): dictionary of magnet parameters, including
                 {
                     'coils_file_path': path to coil filament data file (str).
                     'start_line': starting line index for data in file (int).
@@ -161,9 +171,6 @@ class Stellarator(object):
                 ['rectangle' (str), width [cm](double), thickness [cm](double)]
         """
 
-        magnets_dict = magnets_def.copy()
-        magnets_dict.update(magnets)
-
         self.magnet_set = mc.MagnetSet(
             magnets_dict['coils_file_path'], magnets_dict['start_line'],
             magnets_dict['cross_section'], magnets_dict['toroidal_extent'],
@@ -172,6 +179,9 @@ class Stellarator(object):
         )
 
         self.magnet_set.build_magnet_coils()
+
+    def export_magnets(self, magnets_dict):
+
         self.magnet_set.export_step(
             filename=magnets_dict['step_filename'],
             export_dir=magnets_dict['export_dir']
@@ -184,11 +194,12 @@ class Stellarator(object):
                 export_dir=magnets_dict['export_dir']
             )
 
-    def construct_source_mesh(self, source):
+
+    def construct_source_mesh(self, source_dict):
         """Constructs SourceMesh class object.
 
         Arguments:
-            source (dict): dictionary of source mesh parameters including
+            source_dict (dict): dictionary of source mesh parameters including
                 {
                     'num_s': number of closed flux surfaces for vertex
                         locations in each toroidal plane (int).
@@ -206,9 +217,6 @@ class Stellarator(object):
                         (str, defaults to empty string).
                 }
         """
-        source_dict = source_def.copy()
-        source_dict.update(source)
-
         self.source_mesh = sm.SourceMesh(
             self.vmec, source_dict['num_s'], source_dict['num_theta'],
             source_dict['num_phi'], source_dict['toroidal_extent'],
@@ -217,6 +225,9 @@ class Stellarator(object):
 
         self.source_mesh.create_vertices()
         self.source_mesh.create_mesh()
+
+    def export_source_mesh(self, source_dict):
+
         self.source_mesh.export_mesh(
             filename=source_dict['filename'],
             export_dir=source_dict['export_dir']
@@ -404,20 +415,27 @@ def parastell():
 
     stellarator = Stellarator(vmec_file)
 
+    # Invessel Build
     ivb_dict = invessel_build_def.copy()
     ivb_dict.update(invessel_build)
 
     stellarator.construct_invessel_build(ivb_dict)
-    stellarator.invessel_build.export_step(export_dir=ivb_dict['export_dir'])
+    stellarator.export_invessel_build(ivb_dict)
 
-    if ivb_dict['export_cad_to_dagmc']:
-        stellarator.invessel_build.export_cad_to_dagmc(
-            filename=ivb_dict['dagmc_filename'],
-            export_dir=ivb_dict['export_dir']
-        )
+    # Magnets
+    magnets_dict = magnets_def.copy()
+    magnets_dict.update(magnets)
 
     stellarator.construct_magnets(magnets)
-    stellarator.construct_source_mesh(source)
+
+    # Source Mesh
+    source_dict = source_def.copy()
+    source_dict.update(source)
+
+    stellarator.construct_source_mesh(source_dict)
+    stellarator.export_source_mesh(source_dict)
+
+    
     stellarator.export_dagmc(dagmc_export)
 
 

--- a/src/parastell.py
+++ b/src/parastell.py
@@ -6,17 +6,12 @@ from src.cubit_io import (
 import src.invessel_build as ivb
 import src.magnet_coils as mc
 import src.source_mesh as sm
-from src.utils import def_default_params
+from src.utils import invessel_build_def, magnets_def, source_def,
+    dagmc_export_def
 import log
 import read_vmec
 import argparse
 import yaml
-
-(
-    _, cubit_initialized, invessel_build_def, magnets_def, source_def,
-    dagmc_export_def
-) = def_default_params()
-
 
 class Stellarator(object):
     """Parametrically generates a fusion stellarator reactor core model using

--- a/src/parastell.py
+++ b/src/parastell.py
@@ -357,9 +357,6 @@ class Stellarator(object):
             'Exporting DAGMC neutronics model...'
         )
 
-        export_dict = dagmc_export_def.copy()
-        export_dict.update(dagmc_export)
-
         if self.invessel_build:
             self._import_ivb_step()
 
@@ -447,8 +444,10 @@ def parastell():
     stellarator.construct_source_mesh(source_dict)
     stellarator.export_source_mesh(source_dict)
 
+    export_dict = dagmc_export_def.copy()
+    export_dict.update(dagmc_export)
     
-    stellarator.export_dagmc(dagmc_export)
+    stellarator.export_dagmc(export_dict)
 
 
 if __name__ == "__main__":

--- a/src/source_mesh.py
+++ b/src/source_mesh.py
@@ -1,11 +1,13 @@
 import argparse
 import yaml
 import log
-from src.utils import m2cm, source_def
-import read_vmec
+from pathlib import Path
+
 import numpy as np
 from pymoab import core, types
-from pathlib import Path
+import read_vmec
+
+from src.utils import m2cm, source_def
 
 def rxn_rate(s):
     """Calculates fusion reaction rate in plasma.

--- a/src/source_mesh.py
+++ b/src/source_mesh.py
@@ -1,14 +1,11 @@
 import argparse
 import yaml
 import log
-from src.utils import def_default_params
+from src.utils import m2cm, source_def
 import read_vmec
 import numpy as np
 from pymoab import core, types
 from pathlib import Path
-
-m2cm, _, _, _, source_def, _ = def_default_params()
-
 
 def rxn_rate(s):
     """Calculates fusion reaction rate in plasma.

--- a/src/utils.py
+++ b/src/utils.py
@@ -1,5 +1,6 @@
-import numpy as np
 import math
+
+import numpy as np
 
 m2cm = 100
 

--- a/src/utils.py
+++ b/src/utils.py
@@ -1,6 +1,7 @@
 import numpy as np
 import math
 
+m2cm = 100
 
 def normalize(vec_list):
     """Normalizes a set of vectors.
@@ -54,136 +55,124 @@ def expand_ang_list(ang_list, num_ang):
 
     return ang_list_exp
 
+# invessel_build_def (dict): dictionary of in-vessel component
+#     parameters, including
+#     {
+#         'repeat': number of times to repeat build segment for full
+#             model (int, defaults to 0).
+#         'num_ribs': total number of ribs over which to loft for each
+#             build segment (int, defaults to 61). Ribs are set at
+#             toroidal angles interpolated between those specified in
+#             'toroidal_angles' if this value is greater than the number
+#             of entries in 'toroidal_angles'.
+#         'num_rib_pts': total number of points defining each rib spline
+#             (int, defaults to 61). Points are set at poloidal angles
+#             interpolated between those specified in 'poloidal_angles'
+#             if this value is greater than the number of entries in
+#             'poloidal_angles'.
+#         'scale': a scaling factor between the units of VMEC and [cm]
+#             (double, defaults to m2cm = 100).
+#         'export_cad_to_dagmc': export DAGMC neutronics H5M file of
+#             in-vessel components via CAD-to-DAGMC (bool, defaults to
+#             False).
+#         'plasma_mat_tag': alternate DAGMC material tag to use for
+#             plasma. If none is supplied, 'plasma' will be used (str,
+#             defaults to None).
+#         'sol_mat_tag': alternate DAGMC material tag to use for
+#             scrape-off layer. If none is supplied, 'sol' will be used
+#             (str, defaults to None).
+#         'dagmc_filename': name of DAGMC output file, excluding '.h5m'
+#             extension (str, defaults to 'dagmc').
+#         'export_dir': directory to which to export the output files
+#             (str, defaults to empty string).
+# }
 
-def def_default_params():
-    """Define default parameters for ParaStell.
+invessel_build_def = {
+    'repeat': 0,
+    'num_ribs': 61,
+    'num_rib_pts': 61,
+    'scale': m2cm,
+    'export_cad_to_dagmc': False,
+    'plasma_mat_tag': None,
+    'sol_mat_tag': None,
+    'dagmc_filename': 'dagmc',
+    'export_dir': ''
+}
+ 
+# magnets_def (dict): dictionary of magnet parameters, including
+#     {
+#         'sample_mod': sampling modifier for filament points (int,
+#             defaults to 1). For a user-supplied value of n, sample
+#             every n points in list of points in each filament.
+#         'scale': a scaling factor between the units of the filament
+#             data and [cm] (double, defaults to m2cm = 100).
+#         'step_filename': name of STEP export output file, excluding
+#             '.step' extension (str, defaults to 'magnets').
+#         'mat_tag': DAGMC material tag for magnets in DAGMC neutronics
+#             model (str, defaults to 'magnets').
+#         'export_mesh': flag to indicate tetrahedral mesh generation for
+#             magnet volumes (bool, defaults to False).
+#         'mesh_filename': name of tetrahedral mesh H5M file, excluding
+#             '.h5m' extension (str, defaults to 'magnet_mesh').
+#         'export_dir': directory to which to export output files (str,
+#             defaults to empty string).
+#     }
+magnets_def = {
+    'sample_mod': 1,
+    'scale': m2cm,
+    'step_filename': 'magnets',
+    'mat_tag': 'magnets',
+    'export_mesh': False,
+    'mesh_filename': 'magnet_mesh',
+    'export_dir': ''
+}
 
-    Returns:
-        m2cm (float): factor to convert meters to cm.
-        cubit_initialized (bool): flag to indicate whether Coreform Cubit has
-            been initialized.
-        invessel_build_def (dict): dictionary of in-vessel component
-            parameters, including
-            {
-                'repeat': number of times to repeat build segment for full
-                    model (int, defaults to 0).
-                'num_ribs': total number of ribs over which to loft for each
-                    build segment (int, defaults to 61). Ribs are set at
-                    toroidal angles interpolated between those specified in
-                    'toroidal_angles' if this value is greater than the number
-                    of entries in 'toroidal_angles'.
-                'num_rib_pts': total number of points defining each rib spline
-                    (int, defaults to 61). Points are set at poloidal angles
-                    interpolated between those specified in 'poloidal_angles'
-                    if this value is greater than the number of entries in
-                    'poloidal_angles'.
-                'scale': a scaling factor between the units of VMEC and [cm]
-                    (double, defaults to m2cm = 100).
-                'export_cad_to_dagmc': export DAGMC neutronics H5M file of
-                    in-vessel components via CAD-to-DAGMC (bool, defaults to
-                    False).
-                'plasma_mat_tag': alternate DAGMC material tag to use for
-                    plasma. If none is supplied, 'plasma' will be used (str,
-                    defaults to None).
-                'sol_mat_tag': alternate DAGMC material tag to use for
-                    scrape-off layer. If none is supplied, 'sol' will be used
-                    (str, defaults to None).
-                'dagmc_filename': name of DAGMC output file, excluding '.h5m'
-                    extension (str, defaults to 'dagmc').
-                'export_dir': directory to which to export the output files
-                    (str, defaults to empty string).
-            }
-        magnets_def (dict): dictionary of magnet parameters, including
-            {
-                'sample_mod': sampling modifier for filament points (int,
-                    defaults to 1). For a user-supplied value of n, sample
-                    every n points in list of points in each filament.
-                'scale': a scaling factor between the units of the filament
-                    data and [cm] (double, defaults to m2cm = 100).
-                'step_filename': name of STEP export output file, excluding
-                    '.step' extension (str, defaults to 'magnets').
-                'mat_tag': DAGMC material tag for magnets in DAGMC neutronics
-                    model (str, defaults to 'magnets').
-                'export_mesh': flag to indicate tetrahedral mesh generation for
-                    magnet volumes (bool, defaults to False).
-                'mesh_filename': name of tetrahedral mesh H5M file, excluding
-                    '.h5m' extension (str, defaults to 'magnet_mesh').
-                'export_dir': directory to which to export output files (str,
-                    defaults to empty string).
-            }
-        source_def (dict): dictionary of source mesh parameters including
-            {
-                'scale': a scaling factor between the units of VMEC and [cm]
-                    (double, defaults to m2cm = 100).
-                'filename': name of H5M output file, excluding '.h5m' extension
-                    (str, defaults to 'source_mesh').
-                'export_dir': directory to which to export H5M output file
-                    (str, defaults to empty string).
-            }
-        dagmc_export_def (dict): dictionary of DAGMC export parameters including
-            {
-                'skip_imprint': choose whether to imprint and merge all in
-                    Coreform Cubit or to merge surfaces based on import order
-                    and geometry information (bool).
-                'legacy_faceting': choose legacy or native faceting for DAGMC
-                    export (bool).
-                'faceting_tolerance': maximum distance a facet may be from
-                    surface of CAD representation for DAGMC export (double).
-                'length_tolerance': maximum length of facet edge for DAGMC
-                    export (double).
-                'normal_tolerance': maximum change in angle between normal
-                    vector of adjacent facets (double).
-                'anisotropic_ratio': controls edge length ratio of elements
-                    (double).
-                'deviation_angle': controls deviation angle of facet from
-                    surface (i.e., lesser deviation angle results in more
-                    elements in areas with greater curvature) (double).
-                'filename': name of DAGMC output file, excluding '.h5m'
-                    extension (str, defaults to 'dagmc').
-                'export_dir': directory to which to export DAGMC output file
-                    (str, defaults to empty string).
-            }
-    """
-    m2cm = 100
-    cubit_initialized = False
-    invessel_build_def = {
-        'repeat': 0,
-        'num_ribs': 61,
-        'num_rib_pts': 61,
-        'scale': m2cm,
-        'export_cad_to_dagmc': False,
-        'plasma_mat_tag': None,
-        'sol_mat_tag': None,
-        'dagmc_filename': 'dagmc',
-        'export_dir': ''
-    }
-    magnets_def = {
-        'sample_mod': 1,
-        'scale': m2cm,
-        'step_filename': 'magnets',
-        'mat_tag': 'magnets',
-        'export_mesh': False,
-        'mesh_filename': 'magnet_mesh',
-        'export_dir': ''
-    }
-    source_def = {
-        'scale': m2cm,
-        'filename': 'source_mesh',
-        'export_dir': ''
-    }
-    dagmc_export_def = {
-        'skip_imprint': False,
-        'legacy_faceting': True,
-        'faceting_tolerance': None,
-        'length_tolerance': None,
-        'normal_tolerance': None,
-        'anisotropic_ratio': 100,
-        'deviation_angle': 5,
-        'filename': 'dagmc',
-        'export_dir': ''
-    }
+# source_def (dict): dictionary of source mesh parameters including
+#     {
+#         'scale': a scaling factor between the units of VMEC and [cm]
+#             (double, defaults to m2cm = 100).
+#         'filename': name of H5M output file, excluding '.h5m' extension
+#             (str, defaults to 'source_mesh').
+#         'export_dir': directory to which to export H5M output file
+#             (str, defaults to empty string).
+#     }
+source_def = {
+    'scale': m2cm,
+    'filename': 'source_mesh',
+    'export_dir': ''
+}
 
-    return (
-        m2cm, cubit_initialized, invessel_build_def, magnets_def, source_def,
-        dagmc_export_def
-    )
+# dagmc_export_def (dict): dictionary of DAGMC export parameters including
+#     {
+#         'skip_imprint': choose whether to imprint and merge all in
+#             Coreform Cubit or to merge surfaces based on import order
+#             and geometry information (bool).
+#         'legacy_faceting': choose legacy or native faceting for DAGMC
+#             export (bool).
+#         'faceting_tolerance': maximum distance a facet may be from
+#             surface of CAD representation for DAGMC export (double).
+#         'length_tolerance': maximum length of facet edge for DAGMC
+#             export (double).
+#         'normal_tolerance': maximum change in angle between normal
+#             vector of adjacent facets (double).
+#         'anisotropic_ratio': controls edge length ratio of elements
+#             (double).
+#         'deviation_angle': controls deviation angle of facet from
+#             surface (i.e., lesser deviation angle results in more
+#             elements in areas with greater curvature) (double).
+#         'filename': name of DAGMC output file, excluding '.h5m'
+#             extension (str, defaults to 'dagmc').
+#         'export_dir': directory to which to export DAGMC output file
+#             (str, defaults to empty string).
+#             }
+dagmc_export_def = {
+    'skip_imprint': False,
+    'legacy_faceting': True,
+    'faceting_tolerance': None,
+    'length_tolerance': None,
+    'normal_tolerance': None,
+    'anisotropic_ratio': 100,
+    'deviation_angle': 5,
+    'filename': 'dagmc',
+    'export_dir': ''
+}

--- a/tests/test_invessel_build.py
+++ b/tests/test_invessel_build.py
@@ -1,8 +1,10 @@
-import src.invessel_build as ivb
-import read_vmec
-import numpy as np
 from pathlib import Path
 
+import numpy as np
+
+import read_vmec
+
+import src.invessel_build as ivb
 
 if Path('plasma.step').exists():
     Path.unlink('plasma.step')
@@ -78,13 +80,11 @@ def test_ivb_exports():
 
     invessel_build.export_cad_to_dagmc()
     """
-    assert Path('plasma.step').exists() == True
-    assert Path('sol.step').exists() == True
-    assert Path('component.step').exists() == True
-    #assert Path('dagmc.h5m').exists() == True
+    assert Path('plasma.step').exists() 
+    assert Path('sol.step').exists() 
+    assert Path('component.step').exists() 
 
     Path.unlink('plasma.step')
     Path.unlink('sol.step')
     Path.unlink('component.step')
-    #Path.unlink('dagmc.h5m')
     Path.unlink('stellarator.log')

--- a/tests/test_invessel_build.py
+++ b/tests/test_invessel_build.py
@@ -2,9 +2,12 @@ from pathlib import Path
 
 import numpy as np
 
+# import this before read_vmec to deal with conflicting 
+# dependencies correctly
+import src.invessel_build as ivb
+
 import read_vmec
 
-import src.invessel_build as ivb
 
 if Path('plasma.step').exists():
     Path.unlink('plasma.step')

--- a/tests/test_magnet_coils.py
+++ b/tests/test_magnet_coils.py
@@ -1,5 +1,6 @@
-import src.magnet_coils as magnet_coils
 from pathlib import Path
+
+import src.magnet_coils as magnet_coils
 
 coils_file_path = Path('files_for_tests') / 'coils.txt'
 start_line = 3
@@ -77,10 +78,10 @@ def test_magnet_exports():
 
     circ_coil_set.build_magnet_coils()
     circ_coil_set.export_step()
+    assert Path('magnets.step').exists() == True
+
     circ_coil_set.mesh_magnets()
     circ_coil_set.export_mesh()
-
-    assert Path('magnets.step').exists() == True
     assert Path('magnet_mesh.h5m').exists() == True
 
     Path.unlink('magnets.step')

--- a/tests/test_magnet_coils.py
+++ b/tests/test_magnet_coils.py
@@ -78,11 +78,11 @@ def test_magnet_exports():
 
     circ_coil_set.build_magnet_coils()
     circ_coil_set.export_step()
-    assert Path('magnets.step').exists() == True
+    assert Path('magnets.step').exists()
 
     circ_coil_set.mesh_magnets()
     circ_coil_set.export_mesh()
-    assert Path('magnet_mesh.h5m').exists() == True
+    assert Path('magnet_mesh.h5m').exists()
 
     Path.unlink('magnets.step')
     Path.unlink('magnet_mesh.h5m')

--- a/tests/test_parastell.py
+++ b/tests/test_parastell.py
@@ -66,21 +66,21 @@ def test_parastell():
 
     stellarator.construct_invessel_build(invessel_build)
     stellarator.export_invessel_build(invessel_build)
-    assert Path('plasma.step').exists() == True
-    assert Path('sol.step').exists() == True
-    assert Path('component.step').exists() == True
-    assert Path('magnets.step').exists() == True
+    assert Path('plasma.step').exists()
+    assert Path('sol.step').exists()
+    assert Path('component.step').exists()
+    assert Path('magnets.step').exists()
 
     stellarator.construct_magnets(magnets)
     stellarator.export_magnets(magnets)
-    assert Path('magnet_mesh.h5m').exists() == True
+    assert Path('magnet_mesh.h5m').exists()
 
     stellarator.construct_source_mesh(source)
     stellarator.export_source_mesh(source)
-    assert Path('source_mesh.h5m').exists() == True
+    assert Path('source_mesh.h5m').exists()
 
     stellarator.export_dagmc()
-    assert Path('dagmc.h5m').exists() == True
+    assert Path('dagmc.h5m').exists()
 
     Path.unlink('plasma.step')
     Path.unlink('sol.step')

--- a/tests/test_parastell.py
+++ b/tests/test_parastell.py
@@ -1,6 +1,8 @@
-import src.parastell as ps
-import numpy as np
 from pathlib import Path
+
+import numpy as np
+
+import src.parastell as ps
 
 
 if Path('plasma.step').exists():
@@ -63,16 +65,21 @@ stellarator = ps.Stellarator(vmec_file)
 def test_parastell():
 
     stellarator.construct_invessel_build(invessel_build)
-    stellarator.construct_magnets(magnets)
-    stellarator.construct_source_mesh(source)
-    stellarator.export_dagmc()
-
+    stellarator.export_invessel_build(invessel_build)
     assert Path('plasma.step').exists() == True
     assert Path('sol.step').exists() == True
     assert Path('component.step').exists() == True
     assert Path('magnets.step').exists() == True
+
+    stellarator.construct_magnets(magnets)
+    stellarator.export_magnets(magnets)
     assert Path('magnet_mesh.h5m').exists() == True
+
+    stellarator.construct_source_mesh(source)
+    stellarator.export_source_mesh(source)
     assert Path('source_mesh.h5m').exists() == True
+
+    stellarator.export_dagmc()
     assert Path('dagmc.h5m').exists() == True
 
     Path.unlink('plasma.step')

--- a/tests/test_parastell.py
+++ b/tests/test_parastell.py
@@ -3,6 +3,8 @@ from pathlib import Path
 import numpy as np
 
 import src.parastell as ps
+from src.utils import ( invessel_build_def, magnets_def, source_def,
+    dagmc_export_def )
 
 
 if Path('plasma.step').exists():
@@ -64,22 +66,33 @@ stellarator = ps.Stellarator(vmec_file)
 
 def test_parastell():
 
-    stellarator.construct_invessel_build(invessel_build)
-    stellarator.export_invessel_build(invessel_build)
+    ivb_dict = invessel_build_def.copy()
+    ivb_dict.update(invessel_build)
+
+    stellarator.construct_invessel_build(ivb_dict)
+    stellarator.export_invessel_build(ivb_dict)
     assert Path('plasma.step').exists()
     assert Path('sol.step').exists()
     assert Path('component.step').exists()
 
-    stellarator.construct_magnets(magnets)
-    stellarator.export_magnets(magnets)
+    magnet_dict = magnets_def.copy()
+    magnet_dict.update(magnets)
+
+    stellarator.construct_magnets(magnet_dict)
+    stellarator.export_magnets(magnet_dict)
     assert Path('magnets.step').exists()
     assert Path('magnet_mesh.h5m').exists()
 
-    stellarator.construct_source_mesh(source)
-    stellarator.export_source_mesh(source)
+    source_dict = source_def.copy()
+    source_dict.update(source)
+
+    stellarator.construct_source_mesh(source_dict)
+    stellarator.export_source_mesh(source_dict)
     assert Path('source_mesh.h5m').exists()
 
-    stellarator.export_dagmc()
+    export_dict = dagmc_export_def.copy()
+
+    stellarator.export_dagmc(export_dict)
     assert Path('dagmc.h5m').exists()
 
     Path.unlink('plasma.step')

--- a/tests/test_parastell.py
+++ b/tests/test_parastell.py
@@ -69,10 +69,10 @@ def test_parastell():
     assert Path('plasma.step').exists()
     assert Path('sol.step').exists()
     assert Path('component.step').exists()
-    assert Path('magnets.step').exists()
 
     stellarator.construct_magnets(magnets)
     stellarator.export_magnets(magnets)
+    assert Path('magnets.step').exists()
     assert Path('magnet_mesh.h5m').exists()
 
     stellarator.construct_source_mesh(source)

--- a/tests/test_source_mesh.py
+++ b/tests/test_source_mesh.py
@@ -70,7 +70,7 @@ def test_export():
     source_mesh.create_mesh()
     source_mesh.export_mesh()
 
-    assert Path('source_mesh.h5m').exists() == True
+    assert Path('source_mesh.h5m').exists()
 
     Path.unlink('source_mesh.h5m')
     Path.unlink('stellarator.log')


### PR DESCRIPTION
Here are a number of changes to the latest update to streamline a number of things.  I used a number of small commits to show the individual changes, mostly distinct from each other. NOTE: this PR will update the `ivc_oo` branch thus changing PR #55 

None of this has been tested since I don't have a robust testing environment for the whole process, so there may be some typo bugs.

* use a more conventional singleton pattern for cubit initialization
* move the defaults to be members of utils rather than returned by a function
* don't overuse try/raise blocks
* make IVB.Surfaces and IVB.Components into dictionaries based on their name since we need this info together often
* put module imports in a more pythonic order - native modules to third party modules to custom dependencies to local modules (hope this doesn't break anything!)
* import cubit_io as module and qualify method names
* separation of concerns in parastell: construction vs export (with docstrings)
* tweak variable names for consistency
* refactor to avoid making the component dictionary that requires special cases between magnets and otherwise