### PR TITLE
Update installation instructions on `oo_version`

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ git clone --single-branch --branch old https://github.com/aaroncbader/pystell_uw
 
 or download the and extract the ZIP file from [PyStell-UW](https://github.com/aaroncbader/pystell_uw/tree/old). Once extracted, add the repository directory to your `PYTHONPATH`.
 
-Note that the `old` branch of PyStell-UW is necessary because there are complications with its `master` branch that prevent its successful integration with ParaStell.
+Note that the `old` branch of PyStell-UW is necessary for compatibility with the current version of ParaStell. There are complications with the `master` branch of PyStell-UW that prevent its successful integration with ParaStell.
 
 ## Install ParaStell
 Download and extract the ParaStell repository:

--- a/README.md
+++ b/README.md
@@ -51,7 +51,9 @@ Download and extract the PyStell-UW repository:
 git clone --single-branch --branch old https://github.com/aaroncbader/pystell_uw.git
 ```
 
-or download the and extract the ZIP file from [PyStell-UW](https://github.com/aaroncbader/pystell_uw). Once extracted, add the repository directory to your `PYTHONPATH`.
+or download the and extract the ZIP file from [PyStell-UW](https://github.com/aaroncbader/pystell_uw/tree/old). Once extracted, add the repository directory to your `PYTHONPATH`.
+
+Note that the `old` branch of PyStell-UW is necessary because there are complications with its `master` branch that prevent its successful integration with ParaStell.
 
 ## Install ParaStell
 Download and extract the ParaStell repository:

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ If you do not have a Coreform Cubit license, you may be able to get one through 
 Download and extract the PyStell-UW repository:
 
 ```
-git clone https://github.com/aaroncbader/pystell_uw.git
+git clone --single-branch --branch old https://github.com/aaroncbader/pystell_uw.git
 ```
 
 or download the and extract the ZIP file from [PyStell-UW](https://github.com/aaroncbader/pystell_uw). Once extracted, add the repository directory to your `PYTHONPATH`.


### PR DESCRIPTION
Changes installation instructions for PyStell-UW to specify cloning the `old` branch. There are several issues with the `master` branch of PyStell-UW that prevent its successful integration with ParaStell.

Closes #72.