### PR TITLE
added area normalization to NWL.py

### DIFF
--- a/NWL/NWL.py
+++ b/NWL/NWL.py
@@ -384,7 +384,7 @@ def plot(NWL_mat, phi_pts, theta_pts, num_levels):
 
     levels = np.linspace(np.min(NWL_mat), np.max(NWL_mat), num = num_levels)
     fig, ax = plt.subplots()
-    CF = ax.contourf(phi_pts, theta_pts, NWL_mat, levels = levels)
+    CF = ax.contourf(phi_pts, theta_pts, NWL_mat.T, levels = levels)
     cbar = plt.colorbar(CF)
     cbar.ax.set_ylabel('NWL (MW)')
     plt.xlabel('Toroidal Angle (degrees)')
@@ -392,9 +392,40 @@ def plot(NWL_mat, phi_pts, theta_pts, num_levels):
     fig.savefig('NWL.png')
 
 
+def area_from_corners(corners):
+    """
+    Calculate an approximation of the area defined by 4 xyz points
+
+    Arguments:
+        corners (4x3 numpy array): list of 4 (x,y,z) points. Connecting the 
+            points in the order given should result in a polygon
+
+    Returns:
+        area (float): approximation of area
+    """
+    # triangle 1
+    v1 = corners[3] - corners[0]
+    v2 = corners[2] - corners[0]
+
+    v3 = np.cross(v1,v2)
+
+    area1 = np.sqrt(np.sum(np.square(v3)))/2
+
+    # triangle 2
+    v1 = corners[1] - corners[0]
+    v2 = corners[2] - corners[0]
+
+    v3 = np.cross(v1,v2)
+
+    area2 = np.sqrt(np.sum(np.square(v3)))/2
+
+    area = area1 + area2
+
+    return area
+
 def NWL_plot(
-    source_file, ss_file, plas_eq, tor_ext, pol_ext, wall_s, num_phi = 101,
-    num_theta = 101, num_levels = 10
+    source_file, ss_file, plas_eq, tor_ext, pol_ext, wall_s, num_phi = 100,
+    num_theta = 101, num_levels = 10, num_crossings = None
     ):
     """Computes and plots NWL.
 
@@ -408,6 +439,8 @@ def NWL_plot(
         num_phi (int): number of toroidal angle bins (defaults to 101).
         num_theta (int): number of poloidal angle bins (defaults to 101).
         num_levels (int): number of contour regions (defaults to 10).
+        num_crossings (int): number of crossings to use from the surface source.
+            If none, then all crossings will be used
     """
     import read_vmec
     
@@ -415,6 +448,9 @@ def NWL_plot(
     pol_ext = np.deg2rad(pol_ext)
     
     coords = extract_coords(source_file)
+
+    if num_crossings is not None:
+        coords = coords[0:num_crossings]
     
     # Load plasma equilibrium data
     vmec = read_vmec.vmec_data(plas_eq)
@@ -451,6 +487,30 @@ def NWL_plot(
     # Define number of source particles
     num_parts = len(coords)
 
-    NWL_mat = count_mat*n_energy*eV2J*SS*J2MJ/num_parts
+    neutron_crossing_mat = count_mat*n_energy*eV2J*SS*J2MJ/num_parts
 
+    # construct array of bin boundaries
+    bin_arr = np.zeros((num_phi+1, num_theta+1, 3))
+
+    for phi_bin, phi in enumerate(phi_bins):
+        for theta_bin, theta in enumerate(theta_bins):
+
+            x,y,z = vmec.vmec2xyz(wall_s,theta,phi)
+            bin_arr[phi_bin, theta_bin, :] = [x,y,z]
+
+    # construct area array
+    area_array = np.zeros((num_phi, num_theta))
+
+    for phi_index in range(num_phi):
+        for theta_index in range(num_theta):
+            # each bin has 4 (x,y,z) corners
+            corner1 = bin_arr[phi_index, theta_index]
+            corner2 = bin_arr[phi_index, theta_index+1]
+            corner3 = bin_arr[phi_index+1, theta_index+1]
+            corner4 = bin_arr[phi_index+1, theta_index]
+            corners = np.array([corner1,corner2,corner3,corner4])
+            area = area_from_corners(corners)
+            area_array[phi_index,theta_index] = area
+
+    NWL_mat = neutron_crossing_mat/area_array
     plot(NWL_mat, phi_pts, theta_pts, num_levels)

--- a/NWL/NWL.py
+++ b/NWL/NWL.py
@@ -427,7 +427,7 @@ def NWL_plot(
     source_file, ss_file, plas_eq, tor_ext, pol_ext, wall_s, num_phi = 100,
     num_theta = 101, num_levels = 10, num_crossings = None
     ):
-    """Computes and plots NWL.
+    """Computes and plots NWL. Assumes toroidal extent is less than 360 degrees
 
     Arguments:
         source_file (str): path to OpenMC surface source file.
@@ -470,6 +470,12 @@ def NWL_plot(
         bins = [num_phi, num_theta],
         range = [[phi_min, phi_max], [theta_min, theta_max]]
     )
+
+    # adjust endpoints to eliminate overlap
+    phi_bins[0] = 0
+    phi_bins[-1] = tor_ext
+    theta_bins[0] = -pol_ext/2
+    theta_bins[-1] = pol_ext/2
 
     # Compute centroids of bin dimensions
     phi_pts = np.linspace(0, tor_ext, num = num_phi)

--- a/NWL/NWL.py
+++ b/NWL/NWL.py
@@ -386,7 +386,7 @@ def plot(NWL_mat, phi_pts, theta_pts, num_levels):
     fig, ax = plt.subplots()
     CF = ax.contourf(phi_pts, theta_pts, NWL_mat.T, levels = levels)
     cbar = plt.colorbar(CF)
-    cbar.ax.set_ylabel('NWL (MW)')
+    cbar.ax.set_ylabel('NWL (MW/m2)')
     plt.xlabel('Toroidal Angle (degrees)')
     plt.ylabel('Poloidal Angle (degrees)')
     fig.savefig('NWL.png')

--- a/NWL/NWL_geom.py
+++ b/NWL/NWL_geom.py
@@ -1,4 +1,4 @@
-import NWL.NWL as NWL
+import NWL as NWL
 import numpy as np
 
 

--- a/NWL/NWL_plot.py
+++ b/NWL/NWL_plot.py
@@ -1,4 +1,4 @@
-import NWL.NWL as NWL
+import NWL as NWL
 import numpy as np
 
 
@@ -8,8 +8,8 @@ ss_file = 'strengths.txt'
 plas_eq = 'plas_eq.nc'
 tor_ext = 90.0
 pol_ext = 360.0
-num_phi = 101
-num_theta = 101
+num_phi = 80
+num_theta = 90
 wall_s = 1.2
 num_levels = 10
 

--- a/NWL/NWL_transport.py
+++ b/NWL/NWL_transport.py
@@ -1,4 +1,4 @@
-import NWL.NWL as NWL
+import NWL as NWL
 
 
 # Define simulation parameters


### PR DESCRIPTION
Calculates the area of each bin by converting the corners to xyz and approximating the area as 2 triangles.

The following plot was generated using NWL_plot.py, and a surface source with a million particles.
![image](https://github.com/svalinn/parastell/assets/84034227/651ba4a6-0c30-4334-98be-204837ed968d)

Importing the points in `bin_arr` to cubit and overlaying on the geometry it can be seen that they align nicely with the geometry, with half size bins at the toroidal and poloidal extent edges
![image](https://github.com/svalinn/parastell/assets/84034227/9e5664ba-4bf3-4109-b863-7979f6d41a8c)

The area from summing `area_array` for the parameters in NWL_plot.py is 228.97m2, and measuring in cubit the area is 229.00 m2.

Fixes #23 