### PR TITLE
updated cad-to-dagmc API usage for v0.6.2 compatability

### DIFF
--- a/parastell.py
+++ b/parastell.py
@@ -391,10 +391,11 @@ def exports(export, components, magnets, logger):
         for comp in components.values():
             model.add_cadquery_object(
                 comp['solid'],
-                material_tags = [comp['h5m_tag']]
             )
+        material_tags = [comp['h5m_tag'] for comp in components.values()]
         model.export_dagmc_h5m_file(
-            filename = dir / filename.with_suffix('.h5m')
+            filename = dir / filename.with_suffix('.h5m'),
+            material_tags = material_tags
         )
 
 


### PR DESCRIPTION
Great to see cad-to-dagmc getting some use. I've been working on that package recently and have made a few releases and improvement

the latest version is 0.6.2 and it moves the material tag to the export call. this was done to allow users to add cad and export to gmsh meshes or unstructured dagmc meshes without needing to give material tags (as they would not be used.

Sorry for the breaking changes.