### PR TITLE
Update integration with PyStell-UW on `main`

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ Download and extract the PyStell-UW repository:
 git clone https://github.com/aaroncbader/pystell_uw.git
 ```
 
-or download the and extract the ZIP file from [PyStell-UW](https://github.com/aaroncbader/pystell_uw). Once extracted, add the repository directory to your `PYTHONPATH`.
+or download and extract the ZIP file from [PyStell-UW](https://github.com/aaroncbader/pystell_uw). Once extracted, add the repository directory to your `PYTHONPATH`.
 
 ## Install ParaStell
 Download and extract the ParaStell repository:

--- a/README.md
+++ b/README.md
@@ -65,12 +65,10 @@ If you do not have a Coreform Cubit license, you may be able to get one through 
 Download and extract the PyStell-UW repository:
 
 ```bash
-git clone --single-branch --branch old https://github.com/aaroncbader/pystell_uw.git
+git clone https://github.com/aaroncbader/pystell_uw.git
 ```
 
-or download the and extract the ZIP file from [PyStell-UW](https://github.com/aaroncbader/pystell_uw/tree/old). Once extracted, add the repository directory to your `PYTHONPATH`.
-
-Note that the `old` branch of PyStell-UW is necessary because there are complications with its `master` branch that prevent its successful integration with ParaStell.
+or download the and extract the ZIP file from [PyStell-UW](https://github.com/aaroncbader/pystell_uw). Once extracted, add the repository directory to your `PYTHONPATH`.
 
 ## Install ParaStell
 Download and extract the ParaStell repository:

--- a/parastell.py
+++ b/parastell.py
@@ -1,7 +1,7 @@
 import magnet_coils
 import source_mesh
 import log
-import read_vmec
+import src.pystell.read_vmec as read_vmec
 import cadquery as cq
 import cubit
 import cad_to_dagmc
@@ -795,7 +795,7 @@ def parastell(
     logger.info('New stellarator build')
     
     # Load plasma equilibrium data
-    vmec = read_vmec.vmec_data(plas_eq)
+    vmec = read_vmec.VMECData(plas_eq)
 
     components = {}
     


### PR DESCRIPTION
Updates syntax in ParaStell's `main` branch to reflect recent updates to its dependency, PyStell-UW.

Closes #72.