### PR TITLE
Add Github action for building a Docker image for testing

### DIFF
--- a/.github/workflows/docker_publish.yml
+++ b/.github/workflows/docker_publish.yml
@@ -55,7 +55,7 @@ jobs:
 
       - name: test secrets
         run: |
-          conda activate parastell_env
+          source activate parastell_env
           sed -e "s/@SERVER@/${rlmSERVER}/" -e "s/@PASSWORD@/${rlmPASSWD}/" /opt/Coreform-Cubit-2023.11/bin/licenses/rlmcloud.in > /opt/Coreform-Cubit-2023.11/bin/licenses/rlmcloud.lic
           cd tests
           pytest -v .

--- a/.github/workflows/docker_publish.yml
+++ b/.github/workflows/docker_publish.yml
@@ -1,0 +1,54 @@
+name: Build & Publish docker image for ParaStell CI
+
+on:
+  # allows us to run workflows manually
+  workflow_dispatch:
+  push:
+    paths:
+      - 'Dockefile'
+      - '.github/workflows/docker_publish.yml'
+
+jobs:
+  build-dependency-img:
+    runs-on: ubuntu-latest
+
+    name: Installing Dependencies and ParaStell
+    steps:
+      - name: Log in to the Container registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Build, Test, and Push ParaStell
+        id: build-parastell
+        uses: docker/build-push-action@v5
+        with:
+          cache-from: type=registry,ref=ghcr.io/svalinn/parastell:ci-layer-cache
+          cache-to: type=registry,ref=ghcr.io/svalinn/parastell:ci-layer-cache,mode=max
+          file: Dockerfile
+          push: true
+          tags: ghcr.io/svalinn/parstell:ci-testing
+
+  test-dependency-img:
+    runs-on: ghcr.io/svalinn/parastell:ci-testing
+
+    name: Testing CI image
+    steps:
+      - name: populate environment
+        run: |
+          echo "rlmSERVER=${{ secrets.rlmSERVER }}" >> "$GITHUB_ENV"
+          echo "rlmPASSWD=${{ secrets.rlmPASSWORD}}" >> "$GITHUB_ENV"
+
+      - name: test secrets
+        run: |
+          echo "${rlmSERVER}"
+          echo "${rlmPASSWORD}"
+          sed -e "s/@SERVER@/${rlmSERVER}/" /opt/Coreform-Cubit-2023.11/bin/licenses/rlmcloud.in
+
+
+

--- a/.github/workflows/docker_publish.yml
+++ b/.github/workflows/docker_publish.yml
@@ -52,8 +52,7 @@ jobs:
         run: |
           echo "rlmSERVER=${{ secrets.RLMSERVER }}" >> "$GITHUB_ENV"
           echo "rlmPASSWD=${{ secrets.RLMPASSWORD}}" >> "$GITHUB_ENV"
-          . ${HOME}/.bashrc
-          conda activate parastell_env
+          . /root/.bashrc
           sed -e "s/@SERVER@/${rlmSERVER}/" -e "s/@PASSWORD@/${rlmPASSWD}/" /opt/Coreform-Cubit-2023.11/bin/licenses/rlmcloud.in > /opt/Coreform-Cubit-2023.11/bin/licenses/rlmcloud.lic
           cd tests
           pytest -v .

--- a/.github/workflows/docker_publish.yml
+++ b/.github/workflows/docker_publish.yml
@@ -53,7 +53,7 @@ jobs:
         run: |
           echo "${rlmSERVER}"
           echo "${rlmPASSWD}"
-          sed -e "s/@SERVER@/${rlmSERVER}/" -e "s/@PASSWORD@/$rlmPASSWD}/" /opt/Coreform-Cubit-2023.11/bin/licenses/rlmcloud.in > /opt/Coreform-Cubit-2023.11/bin/licenses/rlmcloud.lic
+          sed -e "s/@SERVER@/${rlmSERVER}/" -e "s/@PASSWORD@/${rlmPASSWD}/" /opt/Coreform-Cubit-2023.11/bin/licenses/rlmcloud.in > /opt/Coreform-Cubit-2023.11/bin/licenses/rlmcloud.lic
           cat /opt/Coreform-Cubit-2023.11/bin/licenses/rlmcloud.lic
           echo y | coreform_cubit -nographics
 

--- a/.github/workflows/docker_publish.yml
+++ b/.github/workflows/docker_publish.yml
@@ -52,10 +52,8 @@ jobs:
         run: |
           echo "rlmSERVER=${{ secrets.RLMSERVER }}" >> "$GITHUB_ENV"
           echo "rlmPASSWD=${{ secrets.RLMPASSWORD}}" >> "$GITHUB_ENV"
-
-      - name: test secrets
-        run: |
-          source activate parastell_env
+          which conda
+          conda activate parastell_env
           sed -e "s/@SERVER@/${rlmSERVER}/" -e "s/@PASSWORD@/${rlmPASSWD}/" /opt/Coreform-Cubit-2023.11/bin/licenses/rlmcloud.in > /opt/Coreform-Cubit-2023.11/bin/licenses/rlmcloud.lic
           cd tests
           pytest -v .

--- a/.github/workflows/docker_publish.yml
+++ b/.github/workflows/docker_publish.yml
@@ -52,7 +52,7 @@ jobs:
         run: |
           echo "rlmSERVER=${{ secrets.RLMSERVER }}" >> "$GITHUB_ENV"
           echo "rlmPASSWD=${{ secrets.RLMPASSWORD}}" >> "$GITHUB_ENV"
-          which conda
+          conda init
           conda activate parastell_env
           sed -e "s/@SERVER@/${rlmSERVER}/" -e "s/@PASSWORD@/${rlmPASSWD}/" /opt/Coreform-Cubit-2023.11/bin/licenses/rlmcloud.in > /opt/Coreform-Cubit-2023.11/bin/licenses/rlmcloud.lic
           cd tests

--- a/.github/workflows/docker_publish.yml
+++ b/.github/workflows/docker_publish.yml
@@ -39,7 +39,7 @@ jobs:
 
   test-dependency-img:
     needs: build-dependency-img
-    runs-on: ghcr.io/svalinn/parastell-ci
+    runs-on: ghcr.io/svalinn/parastell:ci-layer-cache
 
     name: Testing CI image
     steps:

--- a/.github/workflows/docker_publish.yml
+++ b/.github/workflows/docker_publish.yml
@@ -51,6 +51,7 @@ jobs:
 
       - name: test secrets
         run: |
+          conda activate parastell_env
           echo "${rlmSERVER}"
           echo "${rlmPASSWD}"
           sed -e "s/@SERVER@/${rlmSERVER}/" -e "s/@PASSWORD@/${rlmPASSWD}/" /opt/Coreform-Cubit-2023.11/bin/licenses/rlmcloud.in > /opt/Coreform-Cubit-2023.11/bin/licenses/rlmcloud.lic

--- a/.github/workflows/docker_publish.yml
+++ b/.github/workflows/docker_publish.yml
@@ -46,8 +46,8 @@ jobs:
     steps:
       - name: populate environment
         run: |
-          echo "rlmSERVER=${{ secrets.rlmSERVER }}" >> "$GITHUB_ENV"
-          echo "rlmPASSWD=${{ secrets.rlmPASSWORD}}" >> "$GITHUB_ENV"
+          echo "rlmSERVER=${{ secrets.RLMSERVER }}" >> "$GITHUB_ENV"
+          echo "rlmPASSWD=${{ secrets.RLMPASSWORD}}" >> "$GITHUB_ENV"
 
       - name: test secrets
         run: |

--- a/.github/workflows/docker_publish.yml
+++ b/.github/workflows/docker_publish.yml
@@ -52,7 +52,7 @@ jobs:
         run: |
           echo "rlmSERVER=${{ secrets.RLMSERVER }}" >> "$GITHUB_ENV"
           echo "rlmPASSWD=${{ secrets.RLMPASSWORD}}" >> "$GITHUB_ENV"
-          conda init
+          . ${HOME}/.bashrc
           conda activate parastell_env
           sed -e "s/@SERVER@/${rlmSERVER}/" -e "s/@PASSWORD@/${rlmPASSWD}/" /opt/Coreform-Cubit-2023.11/bin/licenses/rlmcloud.in > /opt/Coreform-Cubit-2023.11/bin/licenses/rlmcloud.lic
           cd tests

--- a/.github/workflows/docker_publish.yml
+++ b/.github/workflows/docker_publish.yml
@@ -54,8 +54,10 @@ jobs:
           echo "${rlmSERVER}"
           echo "${rlmPASSWD}"
           sed -e "s/@SERVER@/${rlmSERVER}/" -e "s/@PASSWORD@/${rlmPASSWD}/" /opt/Coreform-Cubit-2023.11/bin/licenses/rlmcloud.in > /opt/Coreform-Cubit-2023.11/bin/licenses/rlmcloud.lic
-          cat /opt/Coreform-Cubit-2023.11/bin/licenses/rlmcloud.lic
-          echo y | coreform_cubit -nographics
+          cd /opt/parastell/tests
+          pytest -v .
+          
+
 
 
 

--- a/.github/workflows/docker_publish.yml
+++ b/.github/workflows/docker_publish.yml
@@ -52,8 +52,10 @@ jobs:
       - name: test secrets
         run: |
           echo "${rlmSERVER}"
-          echo "${rlmPASSWORD}"
-          sed -e "s/@SERVER@/${rlmSERVER}/" /opt/Coreform-Cubit-2023.11/bin/licenses/rlmcloud.in
+          echo "${rlmPASSWD}"
+          sed -e "s/@SERVER@/${rlmSERVER}/" -e "s/@PASSWORD@/$rlmPASSWD}/" /opt/Coreform-Cubit-2023.11/bin/licenses/rlmcloud.in
+          echo y | coreform_cubit -nographics
+          
 
 
 

--- a/.github/workflows/docker_publish.yml
+++ b/.github/workflows/docker_publish.yml
@@ -55,6 +55,7 @@ jobs:
           . /opt/etc/bashrc
           conda activate parastell_env
           sed -e "s/@SERVER@/${rlmSERVER}/" -e "s/@PASSWORD@/${rlmPASSWD}/" /opt/Coreform-Cubit-2023.11/bin/licenses/rlmcloud.in > /opt/Coreform-Cubit-2023.11/bin/licenses/rlmcloud.lic
+          export PYTHONPATH=${PYTHONPATH}:`pwd`/parastell
           cd tests
           pytest -v .
 

--- a/.github/workflows/docker_publish.yml
+++ b/.github/workflows/docker_publish.yml
@@ -52,7 +52,7 @@ jobs:
         run: |
           echo "rlmSERVER=${{ secrets.RLMSERVER }}" >> "$GITHUB_ENV"
           echo "rlmPASSWD=${{ secrets.RLMPASSWORD}}" >> "$GITHUB_ENV"
-          . ${HOME}/.bashrc
+          . /opt/etc/bashrc
           conda activate parastell_env
           sed -e "s/@SERVER@/${rlmSERVER}/" -e "s/@PASSWORD@/${rlmPASSWD}/" /opt/Coreform-Cubit-2023.11/bin/licenses/rlmcloud.in > /opt/Coreform-Cubit-2023.11/bin/licenses/rlmcloud.lic
           cd tests

--- a/.github/workflows/docker_publish.yml
+++ b/.github/workflows/docker_publish.yml
@@ -53,9 +53,9 @@ jobs:
         run: |
           echo "${rlmSERVER}"
           echo "${rlmPASSWD}"
-          sed -e "s/@SERVER@/${rlmSERVER}/" -e "s/@PASSWORD@/$rlmPASSWD}/" /opt/Coreform-Cubit-2023.11/bin/licenses/rlmcloud.in
+          sed -e "s/@SERVER@/${rlmSERVER}/" -e "s/@PASSWORD@/$rlmPASSWD}/" /opt/Coreform-Cubit-2023.11/bin/licenses/rlmcloud.in > /opt/Coreform-Cubit-2023.11/bin/licenses/rlmcloud.lic
           echo y | coreform_cubit -nographics
-          
+
 
 
 

--- a/.github/workflows/docker_publish.yml
+++ b/.github/workflows/docker_publish.yml
@@ -57,7 +57,7 @@ jobs:
           sed -e "s/@SERVER@/${rlmSERVER}/" -e "s/@PASSWORD@/${rlmPASSWD}/" /opt/Coreform-Cubit-2023.11/bin/licenses/rlmcloud.in > /opt/Coreform-Cubit-2023.11/bin/licenses/rlmcloud.lic
           export PYTHONPATH=${PYTHONPATH}:`pwd`
           cd tests
-          pytest -v test_source_mesh.py
+          pytest -v test_parastell.py
 
 
 

--- a/.github/workflows/docker_publish.yml
+++ b/.github/workflows/docker_publish.yml
@@ -57,7 +57,7 @@ jobs:
           sed -e "s/@SERVER@/${rlmSERVER}/" -e "s/@PASSWORD@/${rlmPASSWD}/" /opt/Coreform-Cubit-2023.11/bin/licenses/rlmcloud.in > /opt/Coreform-Cubit-2023.11/bin/licenses/rlmcloud.lic
           export PYTHONPATH=${PYTHONPATH}:`pwd`
           cd tests
-          pytest -v test_invessel_build.py
+          pytest -v test_source_mesh.py
 
 
 

--- a/.github/workflows/docker_publish.yml
+++ b/.github/workflows/docker_publish.yml
@@ -57,7 +57,7 @@ jobs:
           sed -e "s/@SERVER@/${rlmSERVER}/" -e "s/@PASSWORD@/${rlmPASSWD}/" /opt/Coreform-Cubit-2023.11/bin/licenses/rlmcloud.in > /opt/Coreform-Cubit-2023.11/bin/licenses/rlmcloud.lic
           export PYTHONPATH=${PYTHONPATH}:`pwd`
           cd tests
-          pytest -v .
+          pytest -v test_invessel_build.py
 
 
 

--- a/.github/workflows/docker_publish.yml
+++ b/.github/workflows/docker_publish.yml
@@ -55,7 +55,7 @@ jobs:
           . /opt/etc/bashrc
           conda activate parastell_env
           sed -e "s/@SERVER@/${rlmSERVER}/" -e "s/@PASSWORD@/${rlmPASSWD}/" /opt/Coreform-Cubit-2023.11/bin/licenses/rlmcloud.in > /opt/Coreform-Cubit-2023.11/bin/licenses/rlmcloud.lic
-          export PYTHONPATH=${PYTHONPATH}:`pwd`/parastell
+          export PYTHONPATH=${PYTHONPATH}:`pwd`
           cd tests
           pytest -v .
 

--- a/.github/workflows/docker_publish.yml
+++ b/.github/workflows/docker_publish.yml
@@ -5,7 +5,7 @@ on:
   workflow_dispatch:
   push:
     paths:
-      - 'Dockefile'
+      - 'Dockerfile'
       - '.github/workflows/docker_publish.yml'
 
 jobs:
@@ -56,7 +56,7 @@ jobs:
           sed -e "s/@SERVER@/${rlmSERVER}/" -e "s/@PASSWORD@/${rlmPASSWD}/" /opt/Coreform-Cubit-2023.11/bin/licenses/rlmcloud.in > /opt/Coreform-Cubit-2023.11/bin/licenses/rlmcloud.lic
           cd /opt/parastell/tests
           pytest -v .
-          
+
 
 
 

--- a/.github/workflows/docker_publish.yml
+++ b/.github/workflows/docker_publish.yml
@@ -39,7 +39,8 @@ jobs:
 
   test-dependency-img:
     needs: build-dependency-img
-    runs-on: ghcr.io/svalinn/parastell:ci-layer-cache
+    runs-on: ubuntu-latest
+    container: ghcr.io/svalinn/parstell-ci
 
     name: Testing CI image
     steps:

--- a/.github/workflows/docker_publish.yml
+++ b/.github/workflows/docker_publish.yml
@@ -54,6 +54,7 @@ jobs:
           echo "${rlmSERVER}"
           echo "${rlmPASSWD}"
           sed -e "s/@SERVER@/${rlmSERVER}/" -e "s/@PASSWORD@/$rlmPASSWD}/" /opt/Coreform-Cubit-2023.11/bin/licenses/rlmcloud.in > /opt/Coreform-Cubit-2023.11/bin/licenses/rlmcloud.lic
+          cat /opt/Coreform-Cubit-2023.11/bin/licenses/rlmcloud.lic
           echo y | coreform_cubit -nographics
 
 

--- a/.github/workflows/docker_publish.yml
+++ b/.github/workflows/docker_publish.yml
@@ -35,11 +35,11 @@ jobs:
           cache-to: type=registry,ref=ghcr.io/svalinn/parastell:ci-layer-cache,mode=max
           file: Dockerfile
           push: true
-          tags: ghcr.io/svalinn/parstell:ci-testing
+          tags: ghcr.io/svalinn/parstell-ci
 
   test-dependency-img:
     needs: build-dependency-img
-    runs-on: ghcr.io/svalinn/parastell:ci-testing
+    runs-on: ghcr.io/svalinn/parastell-ci
 
     name: Testing CI image
     steps:

--- a/.github/workflows/docker_publish.yml
+++ b/.github/workflows/docker_publish.yml
@@ -52,7 +52,7 @@ jobs:
         run: |
           echo "rlmSERVER=${{ secrets.RLMSERVER }}" >> "$GITHUB_ENV"
           echo "rlmPASSWD=${{ secrets.RLMPASSWORD}}" >> "$GITHUB_ENV"
-          . /root/.bashrc
+          . ${HOME}/.bashrc
           sed -e "s/@SERVER@/${rlmSERVER}/" -e "s/@PASSWORD@/${rlmPASSWD}/" /opt/Coreform-Cubit-2023.11/bin/licenses/rlmcloud.in > /opt/Coreform-Cubit-2023.11/bin/licenses/rlmcloud.lic
           cd tests
           pytest -v .

--- a/.github/workflows/docker_publish.yml
+++ b/.github/workflows/docker_publish.yml
@@ -15,7 +15,7 @@ jobs:
     name: Installing Dependencies and ParaStell
     steps:
       - name: Log in to the Container registry
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
@@ -38,6 +38,7 @@ jobs:
           tags: ghcr.io/svalinn/parstell:ci-testing
 
   test-dependency-img:
+    needs: build-dependency-img
     runs-on: ghcr.io/svalinn/parastell:ci-testing
 
     name: Testing CI image

--- a/.github/workflows/docker_publish.yml
+++ b/.github/workflows/docker_publish.yml
@@ -24,6 +24,9 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
       - name: Build, Test, and Push ParaStell
         id: build-parastell
         uses: docker/build-push-action@v5

--- a/.github/workflows/docker_publish.yml
+++ b/.github/workflows/docker_publish.yml
@@ -53,6 +53,7 @@ jobs:
           echo "rlmSERVER=${{ secrets.RLMSERVER }}" >> "$GITHUB_ENV"
           echo "rlmPASSWD=${{ secrets.RLMPASSWORD}}" >> "$GITHUB_ENV"
           . ${HOME}/.bashrc
+          conda activate parastell_env
           sed -e "s/@SERVER@/${rlmSERVER}/" -e "s/@PASSWORD@/${rlmPASSWD}/" /opt/Coreform-Cubit-2023.11/bin/licenses/rlmcloud.in > /opt/Coreform-Cubit-2023.11/bin/licenses/rlmcloud.lic
           cd tests
           pytest -v .

--- a/.github/workflows/docker_publish.yml
+++ b/.github/workflows/docker_publish.yml
@@ -35,6 +35,7 @@ jobs:
           cache-to: type=registry,ref=ghcr.io/svalinn/parastell:ci-layer-cache,mode=max
           file: Dockerfile
           push: true
+          target: parastell-deps
           tags: ghcr.io/svalinn/parstell-ci
 
   test-dependency-img:
@@ -44,6 +45,9 @@ jobs:
 
     name: Testing CI image
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
       - name: populate environment
         run: |
           echo "rlmSERVER=${{ secrets.RLMSERVER }}" >> "$GITHUB_ENV"
@@ -52,10 +56,8 @@ jobs:
       - name: test secrets
         run: |
           conda activate parastell_env
-          echo "${rlmSERVER}"
-          echo "${rlmPASSWD}"
           sed -e "s/@SERVER@/${rlmSERVER}/" -e "s/@PASSWORD@/${rlmPASSWD}/" /opt/Coreform-Cubit-2023.11/bin/licenses/rlmcloud.in > /opt/Coreform-Cubit-2023.11/bin/licenses/rlmcloud.lic
-          cd /opt/parastell/tests
+          cd tests
           pytest -v .
 
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -50,7 +50,7 @@ RUN git clone https://github.com/aaroncbader/pystell_uw.git
 ENV PYTHONPATH=$PYTHONPATH:/opt/pystell_uw
 
 # install parastell
-RUN git clone https://github.com/svalinn/parastell.git &&
+RUN git clone https://github.com/svalinn/parastell.git && \
     git checkout gh_action
 ENV PYTHONPATH=$PYTHONPATH:/opt/parastell
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -51,6 +51,7 @@ ENV PYTHONPATH=$PYTHONPATH:/opt/pystell_uw
 
 # install parastell
 RUN git clone https://github.com/svalinn/parastell.git && \
+    cd parastell && \
     git checkout gh_action
 ENV PYTHONPATH=$PYTHONPATH:/opt/parastell
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM continuumio/miniconda3
+FROM continuumio/miniconda3 as parastell-deps
 
 ENV TZ=America/Chicago
 RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
@@ -49,11 +49,14 @@ WORKDIR /opt
 RUN git clone https://github.com/aaroncbader/pystell_uw.git
 ENV PYTHONPATH=$PYTHONPATH:/opt/pystell_uw
 
+WORKDIR /
+
+from parastell-deps as parastell
+
 # install parastell
 RUN git clone https://github.com/svalinn/parastell.git && \
     cd parastell && \
     git checkout gh_action
 ENV PYTHONPATH=$PYTHONPATH:/opt/parastell
 
-WORKDIR /
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -38,6 +38,9 @@ RUN dpkg -i cubit.deb
 ENV PYTHONPATH=/opt/Coreform-Cubit-2023.11/bin/
 COPY ./rlmcloud.in /opt/Coreform-Cubit-2023.11/bin/licenses/rlmcloud.in
 
+RUN mkdir -p /github/home
+ENV HOME /github/home
+
 # parastell env
 COPY ./environment.yml /environment.yml
 RUN conda env create -f environment.yml

--- a/Dockerfile
+++ b/Dockerfile
@@ -50,7 +50,8 @@ RUN git clone https://github.com/aaroncbader/pystell_uw.git
 ENV PYTHONPATH=$PYTHONPATH:/opt/pystell_uw
 
 # install parastell
-RUN git clone https://github.com/svalinn/parastell.git
+RUN git clone https://github.com/svalinn/parastell.git &&
+    git checkout gh_action
 ENV PYTHONPATH=$PYTHONPATH:/opt/parastell
 
 WORKDIR /

--- a/Dockerfile
+++ b/Dockerfile
@@ -40,6 +40,7 @@ COPY ./rlmcloud.in /opt/Coreform-Cubit-2023.11/bin/licenses/rlmcloud.in
 
 RUN mkdir -p /github/home
 ENV HOME /github/home
+RUN cp /root/.bashrc /github/home/.bashrc
 
 # parastell env
 COPY ./environment.yml /environment.yml

--- a/Dockerfile
+++ b/Dockerfile
@@ -44,7 +44,7 @@ RUN cp /root/.bashrc /opt/etc/bashrc
 # parastell env
 COPY ./environment.yml /environment.yml
 RUN conda env create -f environment.yml
-RUN echo "source activate parastell_env" >> /opt/etc/bashrc
+RUN echo "conda activate parastell_env" >> /opt/etc/bashrc
 
 WORKDIR /opt
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -36,7 +36,7 @@ RUN wget -O /cubit.deb https://f002.backblazeb2.com/file/cubit-downloads/Corefor
 # install cubit
 RUN dpkg -i cubit.deb
 ENV PYTHONPATH=/opt/Coreform-Cubit-2023.11/bin/
-COPY ./rlmcloud.in /opt/Coreform-Cubit-2023.11/bin/licenses
+COPY ./rlmcloud.in /opt/Coreform-Cubit-2023.11/bin/licenses/rlmcloud.in
 
 # parastell env
 COPY ./environment.yml /environment.yml

--- a/Dockerfile
+++ b/Dockerfile
@@ -38,14 +38,13 @@ RUN dpkg -i cubit.deb
 ENV PYTHONPATH=/opt/Coreform-Cubit-2023.11/bin/
 COPY ./rlmcloud.in /opt/Coreform-Cubit-2023.11/bin/licenses/rlmcloud.in
 
-RUN mkdir -p /github/home
-ENV HOME /github/home
-RUN cp /root/.bashrc /github/home/.bashrc
+RUN mkdir -p /opt/etc
+RUN cp /root/.bashrc /opt/etc/bashrc
 
 # parastell env
 COPY ./environment.yml /environment.yml
 RUN conda env create -f environment.yml
-RUN echo "source activate parastell_env" >> ~/.bashrc
+RUN echo "source activate parastell_env" >> /opt/etc/bashrc
 
 WORKDIR /opt
 

--- a/dockerfile
+++ b/dockerfile
@@ -36,6 +36,7 @@ RUN wget -O /cubit.deb https://f002.backblazeb2.com/file/cubit-downloads/Corefor
 # install cubit
 RUN dpkg -i cubit.deb
 ENV PYTHONPATH=/opt/Coreform-Cubit-2023.11/bin/
+COPY ./rlmcloud.in /opt/Coreform-Cubit-2023.11/bin/licenses
 
 # parastell env
 COPY ./environment.yml /environment.yml

--- a/environment.yml
+++ b/environment.yml
@@ -9,12 +9,14 @@ dependencies:
   - scikit-learn
   - cadquery
   - moab==5.5.0[build=nompi_tempest_*]
-  - cad_to_dagmc
   - ca-certificates
   - certifi
   - openssl
   - matplotlib
+  - gmsh
+  - python-gmsh
   - pip:
+      - cad_to_dagmc<0.6
       - netcdf4
       - pyyaml
       - pytest

--- a/rlmcloud.in
+++ b/rlmcloud.in
@@ -1,0 +1,5 @@
+#
+# Ports 5053 and 5132 must be open in your firewall for outgoing connections.
+#
+CUSTOMER Wisc isv=csimsoft server=@SERVER@ port=5053 password=@PASSWORD@
+


### PR DESCRIPTION
This adds capabilities to use Github actions to build a docker image that we can then use for CI unit testing.

* builds the docker image only including dependencies
* uses that docker image to run tests
    * checks out the repo
    * saves Github secretes in the environment for the RLM server and RLM password
    * uses `sed` to update the license file with those secrets
    * runs pytests