### PR TITLE
Fix Typo in `InVesselBuild` and Incorporate CAD-to-DAGMC in Testing

### DIFF
--- a/parastell/invessel_build.py
+++ b/parastell/invessel_build.py
@@ -354,7 +354,7 @@ class InVesselBuild(object):
 
         for name, component in self.Components.items():
             model.add_cadquery_object(
-                component, material_tags=[self.radial_build[name]['mat_tag]']]
+                component, material_tags=[self.radial_build[name]['mat_tag']]
             )
 
         export_path = Path(export_dir) / Path(filename).with_suffix('.h5m')

--- a/tests/test_invessel_build.py
+++ b/tests/test_invessel_build.py
@@ -112,14 +112,11 @@ def test_ivb_exports(invessel_build):
     invessel_build.calculate_loci()
     invessel_build.generate_components()
     invessel_build.export_step()
-    """
-    CAD-to-DAGMC export does not currently work; might be an incompatibility
-    between CadQuery and CAD-to-DAGMC versions.
-
     invessel_build.export_cad_to_dagmc()
-    """
+
     assert Path('plasma.step').exists() 
     assert Path('sol.step').exists() 
     assert Path('component.step').exists()
+    assert Path('dagmc.h5m').exists()
 
     remove_files() 


### PR DESCRIPTION
Fixes a typo in the `export_cad_to_dagmc` method of `InVesselBuild` and incorporates that method in `test_invessel_build.py`.

Closes #87.