### PR TITLE
Introduce Null Logger Class

### DIFF
--- a/parastell/invessel_build.py
+++ b/parastell/invessel_build.py
@@ -742,6 +742,15 @@ def parse_args():
         'filename',
         help='YAML file defining ParaStell in-vessel component configuration'
     )
+    parser.add_argument(
+        '-l', '--logger',
+        default=False,
+        help=(
+            'Flag to indicate whether to instantiate a logger object (default: '
+            'False)'
+        ),
+        metavar=''
+    )
 
     return parser.parse_args()
 
@@ -763,7 +772,10 @@ def generate_invessel_build():
 
     vmec_file, invessel_build_dict = read_yaml_config(args.filename)
 
-    logger = log.check_init(None, null_logger=False)
+    if args.logger == True:
+        logger = log.init()
+    else:
+        logger = log.NullLogger()
 
     vmec_obj = read_vmec.VMECData(vmec_file)
 

--- a/parastell/invessel_build.py
+++ b/parastell/invessel_build.py
@@ -671,6 +671,8 @@ class RadialBuild(object):
         }
         
         for name, component in self._radial_build.items():
+            component['thickness_matrix'] = \
+                np.array(component['thickness_matrix'])
             if (
                 component['thickness_matrix'].shape !=
                 (len(self._toroidal_angles), len(self._poloidal_angles))

--- a/parastell/invessel_build.py
+++ b/parastell/invessel_build.py
@@ -761,6 +761,8 @@ def generate_invessel_build():
 
     vmec_file, invessel_build_dict = read_yaml_config(args.filename)
 
+    logger = log.check_init(None, null_logger=False)
+
     vmec_obj = read_vmec.VMECData(vmec_file)
 
     rb_allowed_kwargs = ['plasma_mat_tag', 'sol_mat_tag']
@@ -774,6 +776,7 @@ def generate_invessel_build():
         invessel_build_dict['poloidal_angles'],
         invessel_build_dict['wall_s'],
         invessel_build_dict['radial_build'],
+        logger=logger
         **rb_kwargs
     )
 
@@ -786,7 +789,7 @@ def generate_invessel_build():
     invessel_build = InVesselBuild(
         vmec_obj,
         radial_build,
-        logger=radial_build.logger,
+        logger=logger,
         **ivb_kwargs
     )
 

--- a/parastell/log.py
+++ b/parastell/log.py
@@ -1,4 +1,5 @@
 import logging
+import time
 
 
 class NullLogger(object):
@@ -11,8 +12,10 @@ class NullLogger(object):
     def hasHandlers(self):
         return True
 
-    def info(self, *args):
-        pass
+    def info(self, message):
+        current_time = time.localtime()
+        current_time = time.strftime('%H:%M:%S', current_time)
+        print(f'{current_time}: {message}')
 
     def warning(self, *args):
         pass
@@ -34,7 +37,10 @@ def init():
     # Configure stream handler
     s_handler = logging.StreamHandler()
     # Configure file handler
-    f_handler = logging.FileHandler('stellarator.log')
+    f_handler = logging.FileHandler(
+        filename='stellarator.log',
+        mode='w'
+    )
     # Define and set logging format
     format = logging.Formatter(
         fmt = '%(asctime)s: %(message)s',

--- a/parastell/log.py
+++ b/parastell/log.py
@@ -8,6 +8,9 @@ class NullLogger(object):
     def __init__(self, *args):
         pass
 
+    def hasHandlers(self):
+        return True
+
     def info(self, *args):
         pass
 

--- a/parastell/log.py
+++ b/parastell/log.py
@@ -1,6 +1,23 @@
 import logging
 
 
+class NullLogger(object):
+    """Creates a pseudo logger object mimicking an actual logger object whose
+    methods do nothing when called.
+    """
+    def __init__(self, *args):
+        pass
+
+    def info(self, *args):
+        pass
+
+    def warning(self, *args):
+        pass
+
+    def error(self, *args):
+        pass
+
+
 def init():
     """Creates and configures logger with separate stream and file handlers.
 
@@ -29,16 +46,20 @@ def init():
     return logger
 
 
-def check_init(logger_obj):
+def check_init(logger_obj, null_logger=True):
     """Checks if a logger object has been instantiated, and if not,
     instantiates one.
 
     Arguments:
         logger_obj (object or None): logger object input.
+        null_logger (bool): flag to indicate whether a NullLogger object should
+            be returned (optional, defaults to True).
     Returns:
         logger_obj (object): logger object.
     """
     if logger_obj != None and logger_obj.hasHandlers():
         return logger_obj
+    elif null_logger:
+        return NullLogger()
     else:
         return init()

--- a/parastell/log.py
+++ b/parastell/log.py
@@ -2,11 +2,27 @@ import logging
 import time
 
 
+def check_init(logger_obj):
+    """Checks if a logger object has been instantiated, and if not,
+    instantiates one.
+
+    Arguments:
+        logger_obj (object or None): logger object input.
+
+    Returns:
+        logger_obj (object): logger object.
+    """
+    if logger_obj != None and logger_obj.hasHandlers():
+        return logger_obj
+    else:
+        return NullLogger()
+
+
 class NullLogger(object):
     """Creates a pseudo logger object mimicking an actual logger object whose
     methods do nothing when called.
     """
-    def __init__(self, *args):
+    def __init__(self):
         pass
 
     def hasHandlers(self):
@@ -22,7 +38,7 @@ class NullLogger(object):
 
     def error(self, *args):
         pass
-
+    
 
 def init():
     """Creates and configures logger with separate stream and file handlers.
@@ -30,45 +46,24 @@ def init():
     Returns:
         logger (object): logger object.
     """
-    # Create logger
     logger = logging.getLogger('log')
-    # Configure base logger message level
+
     logger.setLevel(logging.INFO)
-    # Configure stream handler
+
     s_handler = logging.StreamHandler()
-    # Configure file handler
     f_handler = logging.FileHandler(
         filename='stellarator.log',
         mode='w'
     )
-    # Define and set logging format
+
     format = logging.Formatter(
         fmt = '%(asctime)s: %(message)s',
         datefmt = '%H:%M:%S'
     )
     s_handler.setFormatter(format)
     f_handler.setFormatter(format)
-    # Add handlers to logger
+
     logger.addHandler(s_handler)
     logger.addHandler(f_handler)
 
     return logger
-
-
-def check_init(logger_obj, null_logger=True):
-    """Checks if a logger object has been instantiated, and if not,
-    instantiates one.
-
-    Arguments:
-        logger_obj (object or None): logger object input.
-        null_logger (bool): flag to indicate whether a NullLogger object should
-            be returned (optional, defaults to True).
-    Returns:
-        logger_obj (object): logger object.
-    """
-    if logger_obj != None and logger_obj.hasHandlers():
-        return logger_obj
-    elif null_logger:
-        return NullLogger()
-    else:
-        return init()

--- a/parastell/magnet_coils.py
+++ b/parastell/magnet_coils.py
@@ -588,6 +588,15 @@ def parse_args():
     parser.add_argument(
         'filename', help='YAML file defining ParaStell magnet configuration'
     )
+    parser.add_argument(
+        '-l', '--logger',
+        default=False,
+        help=(
+            'Flag to indicate whether to instantiate a logger object (default: '
+            'False)'
+        ),
+        metavar=''
+    )
 
     return parser.parse_args()
 
@@ -609,7 +618,10 @@ def generate_magnet_set():
 
     magnet_coils_dict = read_yaml_config(args.filename)
 
-    logger = log.check_init(None, null_logger=False)
+    if args.logger == True:
+        logger = log.init()
+    else:
+        logger = log.NullLogger()
 
     mc_allowed_kwargs = [
         'start_line', 'sample_mod', 'scale', 'mat_tag'

--- a/parastell/magnet_coils.py
+++ b/parastell/magnet_coils.py
@@ -609,6 +609,8 @@ def generate_magnet_set():
 
     magnet_coils_dict = read_yaml_config(args.filename)
 
+    logger = log.check_init(None, null_logger=False)
+
     mc_allowed_kwargs = [
         'start_line', 'sample_mod', 'scale', 'mat_tag'
     ]
@@ -621,6 +623,7 @@ def generate_magnet_set():
         magnet_coils_dict['coils_file'],
         magnet_coils_dict['cross_section'],
         magnet_coils_dict['toroidal_extent'],
+        logger=logger
         **mc_kwargs
     )
 

--- a/parastell/parastell.py
+++ b/parastell/parastell.py
@@ -467,6 +467,15 @@ def parse_args():
         'filename',
         help='YAML file defining ParaStell stellarator configuration'
     )
+    parser.add_argument(
+        '-l', '--logger',
+        default=False,
+        help=(
+            'Flag to indicate whether to instantiate a logger object (default: '
+            'False)'
+        ),
+        metavar=''
+    )
 
     return parser.parse_args()
 
@@ -494,7 +503,10 @@ def parastell():
         vmec_file, invessel_build, magnet_coils, source_mesh, dagmc_export
     ) = read_yaml_config(args.filename)
 
-    logger = log.check_init(None, null_logger=False)
+    if args.logger == True:
+        logger = log.init()
+    else:
+        logger = log.NullLogger()
 
     stellarator = Stellarator(
         vmec_file,

--- a/parastell/parastell.py
+++ b/parastell/parastell.py
@@ -494,7 +494,12 @@ def parastell():
         vmec_file, invessel_build, magnet_coils, source_mesh, dagmc_export
     ) = read_yaml_config(args.filename)
 
-    stellarator = Stellarator(vmec_file)
+    logger = log.check_init(None, null_logger=False)
+
+    stellarator = Stellarator(
+        vmec_file,
+        logger=logger
+    )
 
     # In-Vessel Build
     

--- a/parastell/source_mesh.py
+++ b/parastell/source_mesh.py
@@ -409,6 +409,15 @@ def parse_args():
         'filename',
         help='YAML file defining ParaStell source mesh configuration'
     )
+    parser.add_argument(
+        '-l', '--logger',
+        default=False,
+        help=(
+            'Flag to indicate whether to instantiate a logger object (default: '
+            'False)'
+        ),
+        metavar=''
+    )
 
     return parser.parse_args()
 
@@ -430,7 +439,10 @@ def generate_source_mesh():
 
     vmec_file, source_mesh_dict = read_yaml_src(args.filename)
 
-    logger = log.check_init(None, null_logger=False)
+    if args.logger == True:
+        logger = log.init()
+    else:
+        logger = log.NullLogger()
 
     vmec_obj = read_vmec.VMECData(vmec_file)
 

--- a/parastell/source_mesh.py
+++ b/parastell/source_mesh.py
@@ -430,6 +430,8 @@ def generate_source_mesh():
 
     vmec_file, source_mesh_dict = read_yaml_src(args.filename)
 
+    logger = log.check_init(None, null_logger=False)
+
     vmec_obj = read_vmec.VMECData(vmec_file)
 
     sm_allowed_kwargs = ['scale']
@@ -441,7 +443,8 @@ def generate_source_mesh():
     source_mesh = SourceMesh(
         vmec_obj,
         source_mesh_dict['mesh_size'],
-        source_mesh_dict['toroidal_extent']
+        source_mesh_dict['toroidal_extent'],
+        logger=logger
         **sm_kwargs
     )
 


### PR DESCRIPTION
Adds a pseudo logger class, `NullLogger`, with some of the same class methods as the built-in Python `logging` class object, but whose methods do nothing when called.

The purpose of `NullLogger` is to streamline ParaStell code but not enforce logging when using the Python API. A logger does get enforced upon the user when using the command-line interface with YAML input.

Depends on #85.

Closes #46.