### PR TITLE
Include conda environment YAML file in CI image Action condition

### DIFF
--- a/.github/workflows/docker_publish.yml
+++ b/.github/workflows/docker_publish.yml
@@ -7,6 +7,7 @@ on:
     paths:
       - 'Dockerfile'
       - '.github/workflows/docker_publish.yml'
+      - 'environment.yml'
 
 jobs:
   build-dependency-img:


### PR DESCRIPTION
Includes `environment.yml` conda environment file in list of files under which the CI Docker image GitHub Action will run.