### PR TITLE
Streamline kwargs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,23 @@
+
+# PRoject specific
+*.csv
+*.step
+*.h5m
+*.txt
+*.nc
+*.jou
+*.ods
+*.vtk
+*.cub
+*.cub5
+*.h5
+*.exo
+!wout_vmec.nc
+.vscode
+*.yaml
+!config.yaml
+*.lic
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]
@@ -128,19 +148,3 @@ dmypy.json
 # Pyre type checker
 .pyre/
 
-*.csv
-*.step
-*.h5m
-*.txt
-*.nc
-*.jou
-*.ods
-*.vtk
-*.cub
-*.cub5
-*.h5
-*.exo
-!wout_vmec.nc
-.vscode
-*.yaml
-!config.yaml

--- a/parastell/invessel_build.py
+++ b/parastell/invessel_build.py
@@ -98,7 +98,7 @@ class InVesselBuild(object):
         self.num_rib_pts = 67
         self.scale = m2cm
 
-        for name in kwarg.keys() & ('repeat', 'num_ribs', 'num_rib_pts', 'scale'):
+        for name in kwargs.keys() & ('repeat', 'num_ribs', 'num_rib_pts', 'scale'):
             self.__setattr__(name,kwargs[name])
 
         self.Surfaces = {}
@@ -568,7 +568,7 @@ class RadialBuild(object):
         self.plasma_mat_tag = 'Vacuum'
         self.sol_mat_tag = 'Vacuum'
 
-        for name in kwarg.keys() & ('plasma_mat_tag', 'sol_mat_tag'):
+        for name in kwargs.keys() & ('plasma_mat_tag', 'sol_mat_tag'):
             self.__setattr__(name,kwargs[name])
 
         self._logger.info(

--- a/parastell/invessel_build.py
+++ b/parastell/invessel_build.py
@@ -14,6 +14,7 @@ from .utils import (
     normalize, expand_ang_list, read_yaml_config, filter_kwargs, m2cm
 )
 
+
 def orient_spline_surfaces(volume_id):
     """Extracts the inner and outer surface IDs for a given ParaStell in-vessel
     component volume in Coreform Cubit.
@@ -796,7 +797,7 @@ def generate_invessel_build():
         
         invessel_build.export_cad_to_dagmc(
             export_dir=args.export_dir,
-            **(filter_kwargs(invessel_build_dict,['dagmc_filename']))
+            **(filter_kwargs(invessel_build_dict, ['dagmc_filename']))
         )
 
 

--- a/parastell/invessel_build.py
+++ b/parastell/invessel_build.py
@@ -98,10 +98,8 @@ class InVesselBuild(object):
         self.num_rib_pts = 67
         self.scale = m2cm
 
-        allowed_kwargs = ['repeat', 'num_ribs', 'num_rib_pts', 'scale']
-        for name in allowed_kwargs:
-            if name in kwargs.keys():
-                self.__setattr__(name,kwargs[name])
+        for name in kwarg.keys() & ('repeat', 'num_ribs', 'num_rib_pts', 'scale'):
+            self.__setattr__(name,kwargs[name])
 
         self.Surfaces = {}
         self.Components = {}
@@ -570,10 +568,8 @@ class RadialBuild(object):
         self.plasma_mat_tag = 'Vacuum'
         self.sol_mat_tag = 'Vacuum'
 
-        allowed_kwargs = ['plasma_mat_tag', 'sol_mat_tag']
-        for name in allowed_kwargs:
-            if name in kwargs.keys():
-                self.__setattr__(name,kwargs[name])
+        for name in kwarg.keys() & ('plasma_mat_tag', 'sol_mat_tag'):
+            self.__setattr__(name,kwargs[name])
 
         self._logger.info(
             'Constructing radial build...'

--- a/parastell/magnet_coils.py
+++ b/parastell/magnet_coils.py
@@ -56,7 +56,7 @@ class MagnetSet(object):
         self.scale = m2cm
         self.mat_tag = 'magnets'
 
-        for name in kwarg.keys() & ('start_line', 'sample_mod', 'scale', 'mat_tag'):
+        for name in kwargs.keys() & ('start_line', 'sample_mod', 'scale', 'mat_tag'):
             self.__setattr__(name,kwargs[name])
 
         cubit_io.init_cubit()

--- a/parastell/magnet_coils.py
+++ b/parastell/magnet_coils.py
@@ -9,7 +9,9 @@ from . import cubit_io as cubit_io
 from .utils import (
     normalize, read_yaml_config, filter_kwargs, m2cm
 )
+
 export_allowed_kwargs = ['step_filename', 'export_mesh', 'mesh_filename']
+
 
 class MagnetSet(object):
     """An object representing a set of modular stellarator magnet coils.
@@ -633,7 +635,7 @@ def generate_magnet_set():
 
     magnet_set.export_step(
         export_dir=args.export_dir,
-        **(filter_kwargs(magnet_coils_dict,['step_filename']))
+        **(filter_kwargs(magnet_coils_dict, ['step_filename']))
     )
 
     if magnet_coils_dict['export_mesh']:

--- a/parastell/magnet_coils.py
+++ b/parastell/magnet_coils.py
@@ -56,10 +56,8 @@ class MagnetSet(object):
         self.scale = m2cm
         self.mat_tag = 'magnets'
 
-        allowed_kwargs = ['start_line', 'sample_mod', 'scale', 'mat_tag']
-        for name in allowed_kwargs:
-            if name in kwargs.keys():
-                self.__setattr__(name,kwargs[name])
+        for name in kwarg.keys() & ('start_line', 'sample_mod', 'scale', 'mat_tag'):
+            self.__setattr__(name,kwargs[name])
 
         cubit_io.init_cubit()
 

--- a/parastell/magnet_coils.py
+++ b/parastell/magnet_coils.py
@@ -7,10 +7,9 @@ import cubit
 from . import log
 from . import cubit_io as cubit_io 
 from .utils import (
-    normalize, read_yaml_config, construct_kwargs_from_dict, set_kwarg_attrs,
-    m2cm
+    normalize, read_yaml_config, filter_kwargs, m2cm
 )
-
+export_allowed_kwargs = ['step_filename', 'export_mesh', 'mesh_filename']
 
 class MagnetSet(object):
     """An object representing a set of modular stellarator magnet coils.
@@ -58,11 +57,9 @@ class MagnetSet(object):
         self.mat_tag = 'magnets'
 
         allowed_kwargs = ['start_line', 'sample_mod', 'scale', 'mat_tag']
-        set_kwarg_attrs(
-            self,
-            kwargs,
-            allowed_kwargs
-        )
+        for name in allowed_kwargs:
+            if name in kwargs.keys():
+                self.__setattr__(name,kwargs[name])
 
         cubit_io.init_cubit()
 
@@ -626,45 +623,25 @@ def generate_magnet_set():
 
     magnet_coils_dict = all_data['magnet_coils']
 
-    mc_allowed_kwargs = [
-        'start_line', 'sample_mod', 'scale', 'mat_tag'
-    ]
-    mc_kwargs = construct_kwargs_from_dict(
-        magnet_coils_dict,
-        mc_allowed_kwargs
-    )
-    
     magnet_set = MagnetSet(
         magnet_coils_dict['coils_file'],
         magnet_coils_dict['cross_section'],
         magnet_coils_dict['toroidal_extent'],
         logger=logger
-        **mc_kwargs
+        **magnet_coils_dict
     )
 
     magnet_set.build_magnet_coils()
 
-    mc_step_export_allowed_kwargs = ['step_filename']
-    mc_step_export_kwargs = construct_kwargs_from_dict(
-        magnet_coils_dict,
-        mc_step_export_allowed_kwargs
-    )
-
     magnet_set.export_step(
         export_dir=args.export_dir,
-        **mc_step_export_kwargs
+        **(filter_kwargs(magnet_coils_dict,['step_filename']))
     )
 
     if magnet_coils_dict['export_mesh']:
-        mc_mesh_export_allowed_kwargs = ['mesh_filename']
-        mc_mesh_export_kwargs = construct_kwargs_from_dict(
-            magnet_coils_dict,
-            mc_mesh_export_allowed_kwargs
-        )
-
         magnet_set.export_mesh(
             export_dir=args.export_dir,
-            **mc_mesh_export_kwargs
+            **(filter_kwargs(magnet_coils_dict, ['mesh_filename']))
         )
 
 

--- a/parastell/parastell.py
+++ b/parastell/parastell.py
@@ -413,11 +413,15 @@ class Stellarator(object):
             )
 
     def build_full_model(self, invessel_build, magnet_coils, source_mesh):
-        """Use all of the input to make a complete stellarator model
-        with invessel components, magnets, and a source mesh
-        """
+        """Use all of the input to make a complete stellarator model with
+        in-vessel components, magnets, and a source mesh.
 
-        # In-Vessel Build
+        Arguments:
+            invessel_build (dict): dictionary of RadialBuild and InVesselBuild
+                parameters.
+            magnet_coils (dict): dictionary of MagnetSet parameters.
+            source_mesh (dict): dictionary of SourceMesh parameters.
+        """
         self.construct_invessel_build(
             invessel_build['toroidal_angles'],
             invessel_build['poloidal_angles'],
@@ -426,7 +430,6 @@ class Stellarator(object):
             **invessel_build
         )
 
-        # Magnet Coils
         self.construct_magnets(
             magnet_coils['coils_file'],
             magnet_coils['cross_section'],
@@ -434,16 +437,28 @@ class Stellarator(object):
             **magnet_coils
         )
 
-        # Source Mesh
         self.construct_source_mesh(
             source_mesh['mesh_size'],
             source_mesh['toroidal_extent'],
             **source_mesh
         )
 
-    def export_full_model(self, export_dir, invessel_build, 
-                          magnet_coils, source_mesh, dagmc_export):
-    
+    def export_full_model(
+        self, invessel_build, magnet_coils, source_mesh, dagmc_export,
+        export_dir=''
+    ):
+        """Exports a complete stellarator model when in-vessel components,
+        magnets, and source mesh have been constructed.
+
+        Arguments:
+            invessel_build (dict): dictionary of RadialBuild and InVesselBuild
+                parameters.
+            magnet_coils (dict): dictionary of MagnetSet parameters.
+            source_mesh (dict): dictionary of SourceMesh parameters.
+            dagmc_export (dict): dictionary of DAGMC export parameters.
+            export_dir (str): directory to which output files are exported
+                (optional, defaults to empty string).
+        """
         export_cad_to_dagmc = invessel_build.get('export_cad_to_dagmc', False)
         dagmc_filename = invessel_build.get('dagmc_filename', 'dagmc')
 
@@ -455,7 +470,7 @@ class Stellarator(object):
         
         self.export_magnets(
             export_dir=export_dir,
-            **(filter_kwargs(magnet_coils,mc.export_allowed_kwargs))
+            **(filter_kwargs(magnet_coils, mc.export_allowed_kwargs))
         )
 
         self.export_source_mesh(
@@ -463,7 +478,6 @@ class Stellarator(object):
             **(filter_kwargs(source_mesh, sm.export_allowed_kwargs))
         )
         
-        # DAGMC export
         self.export_dagmc(
             export_dir=export_dir,
             **dagmc_export
@@ -617,15 +631,19 @@ def parastell():
         logger=logger
     )
 
-    stellarator.build_full_model(all_data['invessel_build'],
-                                 all_data['magnet_coils'],
-                                 all_data['source_mesh'])
+    stellarator.build_full_model(
+        all_data['invessel_build'],
+        all_data['magnet_coils'],
+        all_data['source_mesh']
+    )
 
-    stellarator.export_full_model(args.export_dir,
-                                  all_data['invesel_build'],
-                                  all_data['magnet_coils'],
-                                  all_data['source_mesh'],
-                                  all_data['dagmc_export'])
+    stellarator.export_full_model(
+        all_data['invesel_build'],
+        all_data['magnet_coils'],
+        all_data['source_mesh'],
+        all_data['dagmc_export'],
+        export_dir=args.export_dir,
+    )
     
 
 if __name__ == "__main__":

--- a/parastell/parastell.py
+++ b/parastell/parastell.py
@@ -457,6 +457,107 @@ class Stellarator(object):
                 **kwargs
             )
 
+    def build_full_model(self, invessel_build, magnet_coils, source_mesh):
+        """Use all of the input to make a complete stellarator model
+        with invessel components, magnets, and a source mesh
+        """
+
+        # In-Vessel Build
+                
+        ivb_construct_allowed_kwargs = [
+            'plasma_mat_tag', 'sol_mat_tag', 'repeat', 'num_ribs', 'num_rib_pts',
+            'scale'
+        ]
+        ivb_construct_kwargs = construct_kwargs_from_dict(
+            invessel_build,
+            ivb_construct_allowed_kwargs
+        )
+        
+        self.construct_invessel_build(
+            invessel_build['toroidal_angles'],
+            invessel_build['poloidal_angles'],
+            invessel_build['wall_s'],
+            invessel_build['radial_build'],
+            **ivb_construct_kwargs
+        )
+
+        # Magnet Coils
+        
+        mc_construct_allowed_kwargs = [
+            'start_line', 'sample_mod', 'scale', 'mat_tag'
+        ]
+        mc_construct_kwargs = construct_kwargs_from_dict(
+            magnet_coils,
+            mc_construct_allowed_kwargs
+        )
+        
+        self.construct_magnets(
+            magnet_coils['coils_file'],
+            magnet_coils['cross_section'],
+            magnet_coils['toroidal_extent'],
+            **mc_construct_kwargs
+        )
+
+        # Source Mesh
+
+        sm_construct_allowed_kwargs = ['scale']
+        sm_construct_kwargs = construct_kwargs_from_dict(
+            source_mesh,
+            sm_construct_allowed_kwargs
+        )
+
+        self.construct_source_mesh(
+            source_mesh['mesh_size'],
+            source_mesh['toroidal_extent'],
+            **sm_construct_kwargs
+        )
+
+    def export_full_model(self, export_dir, invessel_build, 
+                          magnet_coils, source_mesh, dagmc_export):
+    
+        ivb_export_allowed_kwargs = [
+            'export_cad_to_dagmc', 'dagmc_filename'
+        ]
+        ivb_export_kwargs = construct_kwargs_from_dict(
+            invessel_build,
+            ivb_export_allowed_kwargs
+        )
+
+        self.export_invessel_build(
+            export_dir=export_dir,
+            **ivb_export_kwargs
+        )
+
+        mc_export_allowed_kwargs = [
+            'step_filename', 'export_mesh', 'mesh_filename'
+        ]
+        mc_export_kwargs = construct_kwargs_from_dict(
+            magnet_coils,
+            mc_export_allowed_kwargs
+        )
+
+        self.export_magnets(
+            export_dir=export_dir,
+            **mc_export_kwargs
+        )
+
+        sm_export_allowed_kwargs = ['filename']
+        sm_export_kwargs = construct_kwargs_from_dict(
+            source_mesh,
+            sm_export_allowed_kwargs
+        )
+
+        self.export_source_mesh(
+            export_dir=export_dir,
+            **sm_export_kwargs
+        )
+        
+        # DAGMC export
+        self.export_dagmc(
+            export_dir=export_dir,
+            **dagmc_export
+        )
+
 
 def parse_args():
     """Parser for running as a script.
@@ -605,107 +706,16 @@ def parastell():
         logger=logger
     )
 
-    # In-Vessel Build
+    stellarator.build_full_model(all_data['invessel_build'],
+                                 all_data['magnet_coils'],
+                                 all_data['source_mesh'])
 
-    invessel_build = all_data['invessel_build']
+    stellarator.export_full_model(args.export_dir,
+                                  all_data['invesel_build'],
+                                  all_data['magnet_coils'],
+                                  all_data['source_mesh'],
+                                  all_data['dagmc_export'])
     
-    ivb_construct_allowed_kwargs = [
-        'plasma_mat_tag', 'sol_mat_tag', 'repeat', 'num_ribs', 'num_rib_pts',
-        'scale'
-    ]
-    ivb_construct_kwargs = construct_kwargs_from_dict(
-        invessel_build,
-        ivb_construct_allowed_kwargs
-    )
-    
-    stellarator.construct_invessel_build(
-        invessel_build['toroidal_angles'],
-        invessel_build['poloidal_angles'],
-        invessel_build['wall_s'],
-        invessel_build['radial_build'],
-        **ivb_construct_kwargs
-    )
-
-    ivb_export_allowed_kwargs = [
-        'export_cad_to_dagmc', 'dagmc_filename'
-    ]
-    ivb_export_kwargs = construct_kwargs_from_dict(
-        invessel_build,
-        ivb_export_allowed_kwargs
-    )
-
-    stellarator.export_invessel_build(
-        export_dir=args.export_dir,
-        **ivb_export_kwargs
-    )
-
-    # Magnet Coils
-
-    magnet_coils = all_data['magnet_coils']
-    
-    mc_construct_allowed_kwargs = [
-        'start_line', 'sample_mod', 'scale', 'mat_tag'
-    ]
-    mc_construct_kwargs = construct_kwargs_from_dict(
-        magnet_coils,
-        mc_construct_allowed_kwargs
-    )
-    
-    stellarator.construct_magnets(
-        magnet_coils['coils_file'],
-        magnet_coils['cross_section'],
-        magnet_coils['toroidal_extent'],
-        **mc_construct_kwargs
-    )
-
-    mc_export_allowed_kwargs = [
-        'step_filename', 'export_mesh', 'mesh_filename'
-    ]
-    mc_export_kwargs = construct_kwargs_from_dict(
-        magnet_coils,
-        mc_export_allowed_kwargs
-    )
-
-    stellarator.export_magnets(
-        export_dir=args.export_dir,
-        **mc_export_kwargs
-    )
-
-    # Source Mesh
-
-    source_mesh = all_data['source_mesh']
-
-    sm_construct_allowed_kwargs = ['scale']
-    sm_construct_kwargs = construct_kwargs_from_dict(
-        source_mesh,
-        sm_construct_allowed_kwargs
-    )
-
-    stellarator.construct_source_mesh(
-        source_mesh['mesh_size'],
-        source_mesh['toroidal_extent'],
-        **sm_construct_kwargs
-    )
-
-    sm_export_allowed_kwargs = ['filename']
-    sm_export_kwargs = construct_kwargs_from_dict(
-        source_mesh,
-        sm_export_allowed_kwargs
-    )
-
-    stellarator.export_source_mesh(
-        export_dir=args.export_dir,
-        **sm_export_kwargs
-    )
-    
-    # DAGMC export
-    dagmc_export = all_data['dagmc_export']
-
-    stellarator.export_dagmc(
-        export_dir=args.export_dir,
-        **dagmc_export
-    )
-
 
 if __name__ == "__main__":
     parastell()

--- a/parastell/source_mesh.py
+++ b/parastell/source_mesh.py
@@ -6,10 +6,9 @@ from pymoab import core, types
 import src.pystell.read_vmec as read_vmec
 
 from . import log as log
-from .utils import (
-    read_yaml_config, construct_kwargs_from_dict, set_kwarg_attrs, m2cm
-)
+from .utils import read_yaml_config, filter_kwargs, m2cm
 
+export_allowed_kwargs = ['filename']
 
 def rxn_rate(s):
     """Calculates fusion reaction rate in plasma.
@@ -96,11 +95,9 @@ class SourceMesh(object):
         self.scale = m2cm
 
         allowed_kwargs = ['scale']
-        set_kwarg_attrs(
-            self,
-            kwargs,
-            allowed_kwargs
-        )
+        for name in allowed_kwargs:
+            if name in kwargs.keys():
+                self.__setattr__(name,kwargs[name])
         
         self.strengths = []
 
@@ -449,32 +446,20 @@ def generate_source_mesh():
 
     source_mesh_dict = all_data['source_mesh']
 
-    sm_allowed_kwargs = ['scale']
-    sm_kwargs = construct_kwargs_from_dict(
-        source_mesh_dict,
-        sm_allowed_kwargs
-    )
-
     source_mesh = SourceMesh(
         vmec_obj,
         source_mesh_dict['mesh_size'],
         source_mesh_dict['toroidal_extent'],
         logger=logger
-        **sm_kwargs
+        **source_mesh_dict
     )
 
     source_mesh.create_vertices()
     source_mesh.create_mesh()
 
-    sm_export_allowed_kwargs = ['filename']
-    sm_export_kwargs = construct_kwargs_from_dict(
-        source_mesh_dict,
-        sm_export_allowed_kwargs
-    )
-
     source_mesh.export_mesh(
         export_dir=args.export_dir,
-        **sm_export_kwargs
+        **(filter_kwargs(source_mesh_dict,['filename']))
     )
 
 

--- a/parastell/source_mesh.py
+++ b/parastell/source_mesh.py
@@ -94,7 +94,7 @@ class SourceMesh(object):
 
         self.scale = m2cm
 
-        for name in kwarg.keys() & ('scale'):
+        for name in kwargs.keys() & ('scale'):
             self.__setattr__(name,kwargs[name])
         
         self.strengths = []

--- a/parastell/source_mesh.py
+++ b/parastell/source_mesh.py
@@ -10,6 +10,7 @@ from .utils import read_yaml_config, filter_kwargs, m2cm
 
 export_allowed_kwargs = ['filename']
 
+
 def rxn_rate(s):
     """Calculates fusion reaction rate in plasma.
 
@@ -457,7 +458,7 @@ def generate_source_mesh():
 
     source_mesh.export_mesh(
         export_dir=args.export_dir,
-        **(filter_kwargs(source_mesh_dict,['filename']))
+        **(filter_kwargs(source_mesh_dict, ['filename']))
     )
 
 

--- a/parastell/source_mesh.py
+++ b/parastell/source_mesh.py
@@ -94,10 +94,8 @@ class SourceMesh(object):
 
         self.scale = m2cm
 
-        allowed_kwargs = ['scale']
-        for name in allowed_kwargs:
-            if name in kwargs.keys():
-                self.__setattr__(name,kwargs[name])
+        for name in kwarg.keys() & ('scale'):
+            self.__setattr__(name,kwargs[name])
         
         self.strengths = []
 

--- a/parastell/utils.py
+++ b/parastell/utils.py
@@ -92,16 +92,15 @@ def filter_kwargs(
     Returns:
         kwarg_dict (dict): dictionary of keyword arguments and values.
     """
-    kwarg_dict = {}
-    for name, value in dict.items():
-        if name in allowed_kwargs:
-            kwarg_dict.update({name: value})
-        elif all_kwargs:
-            e = ValueError(
-                f'{name} is not a supported keyword argument of '
-                f'"{fn_name}"'
-            )
-            logger.error(e.args[0])
-            raise e
+    allowed_keys = dict.keys() & allowed_kwargs
+    extra_keys = dict.keys() - allowed_kwargs
 
-    return kwarg_dict
+    if all_kwargs and extra_keys:
+        e = ValueError(
+            f'{extra_keys} not supported keyword argument(s) of '
+            f'"{fn_name}"'
+        )
+        logger.error(e.args[0])
+        raise e
+            
+    return {name: dict[name] for name in allowed_keys}

--- a/parastell/utils.py
+++ b/parastell/utils.py
@@ -70,7 +70,7 @@ def read_yaml_config(filename):
 
 
 
-def construct_kwargs_from_dict(
+def filter_kwargs(
     dict, allowed_kwargs, all_kwargs=False, fn_name=None, logger=None
 ):
     """Constructs a dictionary of keyword arguments with corresponding values
@@ -105,26 +105,3 @@ def construct_kwargs_from_dict(
             raise e
 
     return kwarg_dict
-
-
-def set_kwarg_attrs(
-    class_obj, kwargs, allowed_kwargs
-):
-    """Sets the attributes of a given class object according to a dictionary of
-    keyword argument names and corresponding values.
-
-    Arguments:
-        class_obj (object): class object.
-        kwargs (dict): dictionary of keyword arguments and corresponding values.
-        allowed_kwargs (list of str): list of allowed keyword argument names.
-    """
-    for name, value in kwargs.items():
-        if name in allowed_kwargs:
-            class_obj.__setattr__(name, value)
-        else:
-            e = ValueError(
-                f'{name} is not a supported keyword argument of '
-                f'"{type(class_obj).__name__}"'
-            )
-            class_obj._logger.error(e.args[0])
-            raise e

--- a/parastell/utils.py
+++ b/parastell/utils.py
@@ -3,7 +3,6 @@ import math
 
 import numpy as np
 
-
 m2cm = 100
 
 


### PR DESCRIPTION
As I started looking at implementing NWL in the OO version, I realized that we were kind of heavy-handed with kwargs. I think this finds a better balance. Let me know what you think.

Some explanations for the changes:
1. The old code had the lists of allowable arguments defined in multiple places.  They should be defined in as few places as possible - ideally only one.
2. Most of the uses of `construct_kwargs_from_dict` were for passing into a constructor for some class.  That class is the best place to know what arguments are allowable, so its best to pass in the whole dictionary and then cherry-pick relevant data in the constructor.
3. `set_kwarg_attrs` was the function that cherry-picked from the dictionary, but raised exceptions by default for extra arguments.  We probably discussed this at the time, and I may have recommended or endorsed it, but upon reflection it seems heavy-handed.  It is only because of this that we had to carefully curate the `kwargs` that we passed in the first place and maybe its fine to just silently ignore extra `kwargs`.
4. Once `set_kwarg_attrs` became simpler, I decided to just put the code directly into the constructors rather than as a function.  (this is perhaps dubious in our normal spirit of reuse...)
5. There are a few places that still need to pass in values extracted from dictionaries into function argument lists. Here it is more important to extract them more carefully, but this can be done inline.  I changed the method name from `construct_kwargs_from_dict` to `filter_kwargs` as this is more what it does and makes the name shorter.