### PR TITLE
add option to export to cub5

### DIFF
--- a/Examples/config.yaml
+++ b/Examples/config.yaml
@@ -63,6 +63,7 @@ invessel_build:
       mat_tag: vac_vessel
   plasma_mat_tag: Vacuum
   sol_mat_tag: Vacuum
+  split_chamber: True
   export_cad_to_dagmc: False
 
 magnet_coils:
@@ -82,4 +83,5 @@ source_mesh:
 dagmc_export:
   skip_imprint: False
   legacy_faceting: True
+  export_cub5: False
   filename: dagmc

--- a/Examples/parastell_example.py
+++ b/Examples/parastell_example.py
@@ -97,6 +97,7 @@ stellarator.export_source_mesh(
 stellarator.export_dagmc(
     skip_imprint=False,
     legacy_faceting=True,
+    export_cub5=False,
     filename='dagmc',
     export_dir=export_dir
 )

--- a/parastell/cubit_io.py
+++ b/parastell/cubit_io.py
@@ -72,7 +72,7 @@ def export_cub5(filename, export_dir=''):
     init_cubit()
 
     export_path = Path(export_dir) / Path(filename).with_suffix('.cub5')
-    cubit.cmd(f'')
+    cubit.cmd(f'save cub5 "{export_path}" overwrite')
 
 def export_mesh_cubit(filename, export_dir=''):
     """Exports Cubit mesh to H5M file format, first exporting to Exodus format

--- a/parastell/cubit_io.py
+++ b/parastell/cubit_io.py
@@ -61,6 +61,18 @@ def export_step_cubit(filename, export_dir=''):
     export_path = Path(export_dir) / Path(filename).with_suffix('.step')
     cubit.cmd(f'export step "{export_path}" overwrite')
 
+def export_cub5(filename, export_dir=''):
+    """Export cub5 representation of model (native cubit format)
+    
+    Arguments:
+        filename (str): name of cub5 output file, excluding '.cub5' extension.
+        export_dir (str): directory to which to export the cub5 output file
+        (defaults to empty string).
+    """
+    init_cubit()
+
+    export_path = Path(export_dir) / Path(filename).with_suffix('.cub5')
+    cubit.cmd(f'')
 
 def export_mesh_cubit(filename, export_dir=''):
     """Exports Cubit mesh to H5M file format, first exporting to Exodus format

--- a/parastell/parastell.py
+++ b/parastell/parastell.py
@@ -350,9 +350,8 @@ class Stellarator(object):
                 make_material_block(data['mat_tag'], block_id, vol_id_str)
 
     def export_dagmc(
-        self, skip_imprint=False, legacy_faceting=True, filename='dagmc',
-        export_dir='', **kwargs
-    ):
+        self, skip_imprint=False, legacy_faceting=True, export_cub5=False,
+        filename='dagmc', export_dir='', **kwargs):
         """Exports DAGMC neutronics H5M file of ParaStell components via
         Coreform Cubit.
 
@@ -414,6 +413,12 @@ class Stellarator(object):
                 filename=filename,
                 export_dir=export_dir,
                 **kwargs
+            )
+
+        if export_cub5:
+            cubit_io.export_cub5(
+                filename=filename,
+                export_dir=export_dir
             )
 
 

--- a/parastell/parastell.py
+++ b/parastell/parastell.py
@@ -361,6 +361,8 @@ class Stellarator(object):
                 geometry information (optional, defaults to False).
             legacy_faceting (bool): choose legacy or native faceting for DAGMC
                 export (optional, defaults to True).
+            export_cub5 (bool): choose whether or not to save to the cubit
+                native format after exporting to DAGMC.
             filename (str): name of DAGMC output file, excluding '.h5m'
                 extension (optional, defaults to 'dagmc').
             export_dir (str): directory to which to export DAGMC output file

--- a/tests/test_parastell.py
+++ b/tests/test_parastell.py
@@ -20,6 +20,8 @@ def remove_files():
         Path.unlink('magnet_mesh.h5m')
     if Path('dagmc.h5m').exists():
         Path.unlink('dagmc.h5m')
+    if Path('dagmc.cub5').exists():
+        Path.unlink('dagmc.cub5')
     if Path('source_mesh.h5m').exists():
         Path.unlink('source_mesh.h5m')
     if Path('stellarator.log').exists():
@@ -118,8 +120,9 @@ def test_parastell(stellarator):
 
     filename_exp = 'dagmc'
 
-    stellarator.export_dagmc(filename=filename_exp)
+    stellarator.export_dagmc(filename=filename_exp, export_cub5=True)
 
     assert Path(filename_exp).with_suffix('.h5m').exists()
+    assert Path(filename_exp).with_suffix('.cub5').exists()
 
     remove_files()


### PR DESCRIPTION
added an option to export to cub5 as an optional arg for the `stellarator.export_dagmc()` method. Added a test for this method as well, not sure if it is necessary or not since this is sort of an internal cubit thing and if the DAGMC file gets generated I would expect that the .cub5 file will also be written, though I suppose this test would catch if coreform ever changes that syntax on us.

Also added a small change to config.yaml to allow it to work from the command line, I tested both from the command line and from the python interface and things seem to work as expected. Tests are passing locally as well.

closes #93
works with yaml, and has the same filename as specified for the DAGMC file