### PR TITLE
Update syntax to union repeated component segments

### DIFF
--- a/parastell/invessel_build.py
+++ b/parastell/invessel_build.py
@@ -248,7 +248,7 @@ class InVesselBuild(object):
 
             for angle in segment_angles:
                 rot_segment = segment.rotate((0, 0, 0), (0, 0, 1), angle)
-                component = component.union(rot_segment)
+                component = component.fuse(rot_segment)
 
             self.Components[name] = component
             interior_surface = outer_surface


### PR DESCRIPTION
At some point, CadQuery's syntax to union solids together changed from `Component.union(...)` to `Component.fuse(...)`. This PR updates ParaStell's syntax to reflect that change.