### PR TITLE
resolve missing library when building dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,28 +7,28 @@ RUN apt-get upgrade -y
 
 # Install dependencies
 RUN apt-get install -y libgl1-mesa-glx \
-    libgl1-mesa-dev \
-    libglu1-mesa-dev \
-    freeglut3-dev \
-    libosmesa6 \
-    libosmesa6-dev \
-    libgles2-mesa-dev \
-    curl \
-    wget \
-    libx11-6 \
-    libxt6 \
-    libgl1 \
-    libxcb-icccm4 \
-    libxcb-image0 \
-    libxcb-keysyms1 \
-    libxcb-render-util0 \
-    libxkbcommon-x11-0 \
-    libxcb-randr0 \
-    libxcb-xinerama0 \
-    libxm4 \
-    libtiff5 \
-    libxcursor1 \
-    libxinerama1
+                        libgl1-mesa-dev \
+                        libglu1-mesa-dev \
+                        freeglut3-dev \
+                        libosmesa6 \
+                        libosmesa6-dev \
+                        libgles2-mesa-dev \
+                        curl \
+                        wget \
+                        libx11-6 \
+                        libxt6 \
+                        libgl1 \
+                        libxcb-icccm4 \
+                        libxcb-image0 \
+                        libxcb-keysyms1 \
+                        libxcb-render-util0 \
+                        libxkbcommon-x11-0 \
+                        libxcb-randr0 \
+                        libxcb-xinerama0 \
+                        libxm4 \
+                        libtiff5 \
+                        libxcursor1 \
+                        libxinerama1
 
 # Download Coreform Cubit
 RUN wget -O /cubit.deb https://f002.backblazeb2.com/file/cubit-downloads/Coreform-Cubit/Releases/Linux/Coreform-Cubit-2023.11%2B43088-Lin64.deb

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM continuumio/miniconda3:24.3.0-0 as parastell-deps
+FROM continuumio/miniconda3 as parastell-deps
 
 ENV TZ=America/Chicago
 RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
@@ -26,7 +26,7 @@ RUN apt-get install -y libgl1-mesa-glx \
                         libxcb-randr0 \
                         libxcb-xinerama0 \
                         libxm4 \
-                        libtiff5 \
+                        libtiff5-dev \
                         libxcursor1 \
                         libxinerama1
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM continuumio/miniconda3 as parastell-deps
+FROM continuumio/miniconda3:24.3.0-0 as parastell-deps
 
 ENV TZ=America/Chicago
 RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
@@ -7,28 +7,28 @@ RUN apt-get upgrade -y
 
 # Install dependencies
 RUN apt-get install -y libgl1-mesa-glx \
-                        libgl1-mesa-dev \
-                        libglu1-mesa-dev \
-                        freeglut3-dev \
-                        libosmesa6 \
-                        libosmesa6-dev \
-                        libgles2-mesa-dev \
-                        curl \
-                        wget \
-                        libx11-6 \
-                        libxt6 \
-                        libgl1 \
-                        libxcb-icccm4 \
-                        libxcb-image0 \
-                        libxcb-keysyms1 \
-                        libxcb-render-util0 \
-                        libxkbcommon-x11-0 \
-                        libxcb-randr0 \
-                        libxcb-xinerama0 \
-                        libxm4 \
-                        libtiff5 \
-                        libxcursor1 \
-                        libxinerama1
+    libgl1-mesa-dev \
+    libglu1-mesa-dev \
+    freeglut3-dev \
+    libosmesa6 \
+    libosmesa6-dev \
+    libgles2-mesa-dev \
+    curl \
+    wget \
+    libx11-6 \
+    libxt6 \
+    libgl1 \
+    libxcb-icccm4 \
+    libxcb-image0 \
+    libxcb-keysyms1 \
+    libxcb-render-util0 \
+    libxkbcommon-x11-0 \
+    libxcb-randr0 \
+    libxcb-xinerama0 \
+    libxm4 \
+    libtiff5 \
+    libxcursor1 \
+    libxinerama1
 
 # Download Coreform Cubit
 RUN wget -O /cubit.deb https://f002.backblazeb2.com/file/cubit-downloads/Coreform-Cubit/Releases/Linux/Coreform-Cubit-2023.11%2B43088-Lin64.deb


### PR DESCRIPTION
The Build & publish Docker image for ParaStell CI action currently is failing since `apt-get` cannot find libtiff5. I noticed the base image had updated just prior to this failure, and tried with tag for the previous docker image which resolved the missing library issue.

Fixes #115 