### PR TITLE
Assume pystell is installed properly in Python environment

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
         run: |
           . /opt/etc/bashrc
           sed -e "s/@SERVER@/${rlmSERVER}/" -e "s/@PASSWORD@/${rlmPASSWD}/" /opt/Coreform-Cubit-2023.11/bin/licenses/rlmcloud.in > /opt/Coreform-Cubit-2023.11/bin/licenses/rlmcloud.lic
-          export PYTHONPATH=${PYTHONPATH}:`pwd`
+          export PYTHONPATH=${PYTHONPATH}:`pwd`:/opt/pystell_uw/src
           cd tests
           pytest -v .
         env:

--- a/Dockerfile
+++ b/Dockerfile
@@ -48,8 +48,8 @@ RUN echo "conda activate parastell_env" >> /opt/etc/bashrc
 
 WORKDIR /opt
 
-# Install PyStell-UW
-RUN git clone https://github.com/aaroncbader/pystell_uw.git
-ENV PYTHONPATH=$PYTHONPATH:/opt/pystell_uw
+# Install PyStell-UW into conda environment
+RUN conda activate parastell_env
+RUN python -m pip install git+https://github.com/aaroncbader/pystell_uw.git
 
 WORKDIR /

--- a/Dockerfile
+++ b/Dockerfile
@@ -48,8 +48,8 @@ RUN echo "conda activate parastell_env" >> /opt/etc/bashrc
 
 WORKDIR /opt
 
-# Install PyStell-UW
-RUN git clone https://github.com/aaroncbader/pystell_uw.git
-ENV PYTHONPATH=$PYTHONPATH:/opt/pystell_uw/src
+# Install PyStell-UW into conda environment
+RUN conda activate parastell_env
+RUN python -m pip install git+https://github.com/aaroncbader/pystell_uw.git
 
 WORKDIR /

--- a/Dockerfile
+++ b/Dockerfile
@@ -48,8 +48,8 @@ RUN echo "conda activate parastell_env" >> /opt/etc/bashrc
 
 WORKDIR /opt
 
-# Install PyStell-UW into conda environment
-RUN conda activate parastell_env
-RUN python -m pip install git+https://github.com/aaroncbader/pystell_uw.git
+# Install PyStell-UW
+RUN git clone https://github.com/aaroncbader/pystell_uw.git
+ENV PYTHONPATH=$PYTHONPATH:/opt/pystell_uw/src
 
 WORKDIR /

--- a/README.md
+++ b/README.md
@@ -45,13 +45,11 @@ While it is possible to use ParaStell with older versions of Cubit, additional s
 If you do not have a Coreform Cubit license, you may be able to get one through [Cubit Learn](https://coreform.com/products/coreform-cubit/free-meshing-software/) at no cost.
 
 ### Install PyStell-UW
-Download and extract the PyStell-UW repository:
+To install the PyStell-UW package, run:
 
 ```bash
-git clone https://github.com/aaroncbader/pystell_uw.git
+python -m pip install git+https://github.com/aaroncbader/pystell_uw.git
 ```
-
-or download the and extract the ZIP file from [PyStell-UW](https://github.com/aaroncbader/pystell_uw). Once extracted, add the repository directory to your `PYTHONPATH`.
 
 ## Install ParaStell
 Download and extract the ParaStell repository:

--- a/parastell/invessel_build.py
+++ b/parastell/invessel_build.py
@@ -7,7 +7,7 @@ from scipy.interpolate import RegularGridInterpolator
 import cubit
 import cadquery as cq
 import cad_to_dagmc
-import src.pystell.read_vmec as read_vmec
+import pystell.read_vmec as read_vmec
 
 from . import log
 from .utils import (

--- a/parastell/nwl_utils.py
+++ b/parastell/nwl_utils.py
@@ -2,7 +2,7 @@ import h5py
 import numpy as np
 from scipy.optimize import direct
 import openmc
-import src.pystell.read_vmec as read_vmec
+import pystell.read_vmec as read_vmec
 import matplotlib.pyplot as plt
 
 

--- a/parastell/parastell.py
+++ b/parastell/parastell.py
@@ -4,7 +4,7 @@ from pathlib import Path
 
 import cubit
 import numpy as np
-import src.pystell.read_vmec as read_vmec
+import pystell.read_vmec as read_vmec
 
 from . import log
 

--- a/parastell/source_mesh.py
+++ b/parastell/source_mesh.py
@@ -3,7 +3,7 @@ from pathlib import Path
 
 import numpy as np
 from pymoab import core, types
-import src.pystell.read_vmec as read_vmec
+import pystell.read_vmec as read_vmec
 
 from . import log as log
 from .utils import read_yaml_config, filter_kwargs, m2cm

--- a/tests/test_invessel_build.py
+++ b/tests/test_invessel_build.py
@@ -7,7 +7,7 @@ import pytest
 # dependencies correctly
 import parastell.invessel_build as ivb
 
-import src.pystell.read_vmec as read_vmec
+import pystell.read_vmec as read_vmec
 
 
 def remove_files():

--- a/tests/test_source_mesh.py
+++ b/tests/test_source_mesh.py
@@ -2,7 +2,7 @@ from pathlib import Path
 
 import numpy as np
 import pytest
-import src.pystell.read_vmec as read_vmec
+import pystell.read_vmec as read_vmec
 
 import parastell.source_mesh as sm
 


### PR DESCRIPTION
Right now, imports to pystell are of the form `import src.pystell`. This appears to be the case because pystell uses a `src` directory as the root for its Python package. So, if you add the root directory of the pystell git repository to your `PYTHONPATH`, the imports work correctly. However, pystell has a pyproject.toml file that should be used rather than manipulating the `PYTHONPATH` environment variable. Specifically, pystell can be installed by simply running `pip install git+https://github.com/aaroncbader/pystell_uw.git`.