### PR TITLE
Add ability to provide custom source strength functions

### DIFF
--- a/Examples/custom_source_example.py
+++ b/Examples/custom_source_example.py
@@ -1,0 +1,40 @@
+import subprocess
+import numpy as np
+import pystell.read_vmec as read_vmec
+import parastell.source_mesh as sm
+
+
+# Parastell supports defining custom plasma conditions and reaction rates.
+# These can be passed as keyword arguments both to SourceMesh and to 
+# Stellarator.construct_source_mesh(). Included is an example of defining
+# custom (non-physical) plasma conditions and reaction rates. See the 
+# docstrings in source_mesh.py for additional information.
+
+def my_custom_plasma_conditions(s):
+    T_i = np.sin(s*np.pi)
+    n_i = 1
+    return n_i, T_i
+
+def my_custom_reaction_rate(n_i, T_i):
+    return n_i*T_i
+
+vmec_file = 'wout_vmec.nc'
+
+vmec_obj = read_vmec.VMECData(vmec_file)
+
+mesh_size = (11, 81, 61)
+toroidal_extent = 90.0
+
+source_mesh_obj = sm.SourceMesh(
+    vmec_obj,
+    mesh_size,
+    toroidal_extent,
+    plasma_conditions = my_custom_plasma_conditions,
+    reaction_rate = my_custom_reaction_rate
+)
+source_mesh_obj.create_vertices()
+source_mesh_obj.create_mesh()
+
+# export and convert to vtk for visualization
+source_mesh_obj.export_mesh()
+subprocess.run('mbconvert source_mesh.h5m source_mesh.vtk', shell=True)

--- a/parastell/parastell.py
+++ b/parastell/parastell.py
@@ -274,6 +274,13 @@ class Stellarator(object):
         Optional attributes:
             scale (float): a scaling factor between the units of VMEC and [cm]
                 (defaults to m2cm = 100).
+            plasma_conditions (function): function that takes the plasma
+                parameter s, and returns temperature and ion density with
+                suitable units for the reaction_rate() function. Defaults to 
+                default_plasma_conditions()
+            reaction_rate (function): function that takes the values returned by
+                plasma_conditions() and returns a reaction rate in 
+                reactions/cm3/s
         """
         self.source_mesh = sm.SourceMesh(
             self._vmec_obj,

--- a/parastell/source_mesh.py
+++ b/parastell/source_mesh.py
@@ -100,7 +100,7 @@ class SourceMesh(object):
             the reaction_rate() function. Defaults to 
             default_plasma_conditions()
         reaction_rate (function): function that takes the values returned by
-            plasma_conditions() and returns a reaction rate in 
+            plasma_conditions() and returns a reaction rate in reactions/cm3/s
     """
 
     def __init__(

--- a/parastell/source_mesh.py
+++ b/parastell/source_mesh.py
@@ -12,8 +12,10 @@ export_allowed_kwargs = ['filename']
 
 
 def default_reaction_rate(n_i, T_i):
-    """Default reaction rate formula for DT fusion
-    assumes an equal mixture of D and T in a hot plasma.
+    """Default reaction rate formula for DT fusion assumes an equal mixture of 
+    D and T in a hot plasma. From A. Bader et al 2021 Nucl. Fusion 61 116060 
+    DOI 10.1088/1741-4326/ac2991
+
 
     Arguments:
         n_i (float) : ion density (ions per m3)
@@ -39,7 +41,8 @@ def default_reaction_rate(n_i, T_i):
 
 def default_plasma_conditions(s):
     """Calculates ion density and temperature as a function of the
-    plasma paramter s using assumptions of the ARIES design.
+    plasma paramter s using profiles found in A. Bader et al 2021 Nucl. Fusion 
+    61 116060 DOI 10.1088/1741-4326/ac2991
 
     Arguments:
         s (float): closed magnetic flux surface index in range of 0 (magnetic

--- a/parastell/utils.py
+++ b/parastell/utils.py
@@ -4,7 +4,7 @@ import math
 import numpy as np
 
 m2cm = 100
-
+m3tocm3 = 1e6
 
 def normalize(vec_list):
     """Normalizes a set of vectors.

--- a/parastell/utils.py
+++ b/parastell/utils.py
@@ -4,7 +4,7 @@ import math
 import numpy as np
 
 m2cm = 100
-m3tocm3 = 1e6
+m3tocm3 = m2cm * m2cm * m2cm
 
 def normalize(vec_list):
     """Normalizes a set of vectors.


### PR DESCRIPTION
This PR will allow users to pass custom functions for plasma conditions and reaction rates as keyword arguments to either `Stellarator` or `SourceMesh`. The default behavior is to use the same plasma condition/reaction rate that it always has.

The plasma conditions function takes only one input, the plasma parameter s, and must return whatever inputs are required by the reaction rate function. The reaction rate function should return a single value.

Here's an example where the source strengths follow a sine profile:
![image](https://github.com/svalinn/parastell/assets/84034227/763ebee6-9e86-4cca-8091-ef38552a0542)

Should I extend the parastell_example.py script to include an example of creating a custom source definition as well?

Addresses #51

