### PR TITLE
Update DAGMC export in `nwl_geom_example.py`

### DIFF
--- a/Examples/nwl_geom_example.py
+++ b/Examples/nwl_geom_example.py
@@ -56,9 +56,11 @@ for tet in strengths:
     file.write(f'{tet}\n')
 
 # Export DAGMC neutronics H5M file
-stellarator.export_dagmc(
+stellarator.build_cubit_model(
     skip_imprint=True,
-    legacy_faceting=True,
+    legacy_faceting=True
+)
+stellarator.export_dagmc(
     filename='nwl_geom',
     export_dir=export_dir
 )


### PR DESCRIPTION
Updates the DAGMC export portion of `nwl_geom_example.py` to reflect the new ParaStell workflow and include the `build_cubit_model` method of the `Stellarator` class.