### PR TITLE
Update documentation to clarify behavior of `split_chamber`

### DIFF
--- a/parastell/invessel_build.py
+++ b/parastell/invessel_build.py
@@ -530,7 +530,11 @@ class RadialBuild(object):
             }.
         split_chamber (bool): if wall_s > 1.0, separate interior vacuum
             chamber into plasma and scrape-off layer components (optional,
-            defaults to False).
+            defaults to False). If an item with a 'sol' key is present in the
+            radial_build dictionary, settting this to False will not combine
+            the resultant 'chamber' with 'sol'. To include a custom scrape-off
+            layer definition for 'chamber', add an item with a 'chamber' key
+            and desired 'thickness_matrix' value to the radial_build dictionary.
         logger (object): logger object (optional, defaults to None). If no
             logger is supplied, a default logger will be instantiated.
 

--- a/parastell/parastell.py
+++ b/parastell/parastell.py
@@ -124,7 +124,12 @@ class Stellarator(object):
                 }.
             split_chamber (bool): if wall_s > 1.0, separate interior vacuum
                 chamber into plasma and scrape-off layer components (optional,
-                defaults to False).
+                defaults to False). If an item with a 'sol' key is present in
+                the radial_build dictionary, settting this to False will not
+                combine the resultant 'chamber' with 'sol'. To include a custom
+                scrape-off layer definition for 'chamber', add an item with a
+                'chamber' key and desired 'thickness_matrix' value to the
+                radial_build dictionary.
 
         Optional attributes:
             plasma_mat_tag (str): alternate DAGMC material tag to use for


### PR DESCRIPTION
There is some ambiguity about the behavior of `split_chamber`, especially related to how the inserted `"chamber"` component uses any `thickness_matrix` input. This updates documentation to hopefully make that behavior more transparent.

Closes #144.