### PR TITLE
Use non-interactive backend in nwl utils to avoid matplotlib cubit conflict

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -3,16 +3,17 @@ channels:
   - conda-forge
 dependencies:
   - python=3.11.6
-  - pip=24.0
-  - numpy
+  - pip
+  - numpy=1.26.4
   - scipy
   - scikit-learn
   - cadquery
-  - moab==5.5.0[build=nompi_tempest_*]
+  - moab=5.5.1[build=nompi_tempest_*]
   - cad_to_dagmc
   - ca-certificates
   - certifi
   - openssl
+  - openmc=0.15.0[build=dagmc_nompi_*]
   - matplotlib
   - pip:
       - netcdf4

--- a/parastell/nwl_utils.py
+++ b/parastell/nwl_utils.py
@@ -5,8 +5,10 @@ import openmc
 import pystell.read_vmec as read_vmec
 import matplotlib.pyplot as plt
 import concurrent.futures
-from multiprocessing import cpu_count
 import math
+import matplotlib
+
+matplotlib.use("agg")
 
 
 def extract_ss(ss_file):


### PR DESCRIPTION
With the newest version of openmc (0.15.0) the previous conflict with Cubit seems to have been resolved. The remaining conflict with matplotlib can be resolved as in this PR, allowing the full NWL workflow to be performed in one script. In a future PR the nwl_utils example could be updated to be a single script.