### PR TITLE
Refactor filament data use

### DIFF
--- a/Examples/radial_build_distance_example.py
+++ b/Examples/radial_build_distance_example.py
@@ -1,29 +1,34 @@
 from parastell.radial_distance_utils import *
 
-coils_file = "coils_wistelld.txt"
-circ_cross_section = ["circle", 25]
+coils_file = "coils.example"
+width = 40.0
+thickness = 50.0
 toroidal_extent = 90.0
-vmec_file = "plasma_wistelld.nc"
+vmec_file = "wout_vmec.nc"
 vmec = read_vmec.VMECData(vmec_file)
 
 magnet_set = magnet_coils.MagnetSet(
-    coils_file, circ_cross_section, toroidal_extent
+    coils_file, width, thickness, toroidal_extent
 )
 
 reordered_filaments = get_reordered_filaments(magnet_set)
 
 build_magnet_surface(reordered_filaments)
 
-toroidal_angles = np.linspace(0, 90, 72)
-poloidal_angles = np.linspace(0, 360, 96)
+toroidal_angles = np.linspace(0, 90, num=4)
+poloidal_angles = np.linspace(0, 360, num=4)
 wall_s = 1.08
 
 radial_build_dict = {}
 
 radial_build = ivb.RadialBuild(
-    toroidal_angles, poloidal_angles, wall_s, radial_build_dict
+    toroidal_angles,
+    poloidal_angles,
+    wall_s,
+    radial_build_dict,
+    split_chamber=False,
 )
-build = ivb.InVesselBuild(vmec, radial_build, split_chamber=False)
+build = ivb.InVesselBuild(vmec, radial_build, num_ribs=72, num_rib_pts=96)
 build.populate_surfaces()
 build.calculate_loci()
 ribs = build.Surfaces["chamber"].Ribs

--- a/parastell/magnet_coils.py
+++ b/parastell/magnet_coils.py
@@ -186,15 +186,10 @@ class MagnetSet(object):
 
         # Create filter determining whether each coil lies within model's
         # toroidal extent
-        toroidal_extent_filter = [
-            coil.check_coil_toroidal_extent(lower_bound, upper_bound)
-            for coil in self.magnet_coils
-        ]
-
         filtered_coils = [
             coil
-            for flag, coil in zip(toroidal_extent_filter, self.magnet_coils)
-            if flag
+            for coil in self.magnet_coils
+            if coil.check_coil_toroidal_extent(lower_bound, upper_bound)
         ]
 
         # Compute toroidal angles of filament centers of mass

--- a/parastell/magnet_coils.py
+++ b/parastell/magnet_coils.py
@@ -8,7 +8,7 @@ import cubit
 
 from . import log
 from . import cubit_io as cubit_io
-from .utils import normalize, read_yaml_config, filter_kwargs, m2cm
+from .utils import read_yaml_config, filter_kwargs, m2cm
 
 export_allowed_kwargs = ["step_filename", "export_mesh", "mesh_filename"]
 

--- a/parastell/magnet_coils.py
+++ b/parastell/magnet_coils.py
@@ -189,7 +189,7 @@ class MagnetSet(object):
         filtered_coils = [
             coil
             for coil in self.magnet_coils
-            if coil.check_coil_toroidal_extent(lower_bound, upper_bound)
+            if coil.in_toroidal_extent(lower_bound, upper_bound)
         ]
 
         # Compute toroidal angles of filament centers of mass
@@ -334,7 +334,7 @@ class MagnetCoil(object):
             tangents / np.linalg.norm(tangents, axis=1)[:, np.newaxis]
         )
 
-    def check_coil_toroidal_extent(self, lower_bound, upper_bound):
+    def in_toroidal_extent(self, lower_bound, upper_bound):
         """Determines if the coil lies within a given toroidal angular extent,
         based on filament coordinates.
 

--- a/parastell/magnet_coils.py
+++ b/parastell/magnet_coils.py
@@ -235,7 +235,7 @@ class MagnetSet(object):
         self._instantiate_coils()
         self._compute_radial_distance_data()
         self._filter_coils()
-    
+
     def build_magnet_coils(self):
         """Builds each filament in self.filtered_filaments in cubit, then cuts
         to the toroidal extent using self._cut_magnets().

--- a/parastell/magnet_coils.py
+++ b/parastell/magnet_coils.py
@@ -226,15 +226,21 @@ class MagnetSet(object):
             cut_coil = coil.solid.intersect(toroidal_region)
             coil.solid = cut_coil
 
+    def populate_magnet_coils(self):
+        """Populates MagnetCoil class objects representing each of the magnetic
+        coils that lie within the specified toroidal extent.
+        """
+        self._logger.info("Populating magnet coils...")
+
+        self._instantiate_coils()
+        self._compute_radial_distance_data()
+        self._filter_coils()
+    
     def build_magnet_coils(self):
         """Builds each filament in self.filtered_filaments in cubit, then cuts
         to the toroidal extent using self._cut_magnets().
         """
         self._logger.info("Constructing magnet coils...")
-
-        self._instantiate_coils()
-        self._compute_radial_distance_data()
-        self._filter_coils()
 
         [magnet_coil.create_magnet() for magnet_coil in self.magnet_coils]
 

--- a/parastell/parastell.py
+++ b/parastell/parastell.py
@@ -224,6 +224,7 @@ class Stellarator(object):
             **kwargs,
         )
 
+        self.magnet_set.populate_magnet_coils()
         self.magnet_set.build_magnet_coils()
 
     def export_magnets(

--- a/parastell/radial_distance_utils.py
+++ b/parastell/radial_distance_utils.py
@@ -90,9 +90,10 @@ def reorder_filaments(filaments):
             reordered_filament = np.flip(reordered_filament, axis=0)
 
         # ensure filament is a closed loop
-        reordered_filament = np.concatenate(
-            [reordered_filament, [reordered_filament[0]]]
-        )
+        if max_z_index != 0:
+            reordered_filament = np.concatenate(
+                [reordered_filament, [reordered_filament[0]]]
+            )
 
         filaments[filament_index] = reordered_filament
 
@@ -105,11 +106,13 @@ def get_reordered_filaments(magnet_set):
     """
     Convenience function to get the reordered filament data from a magnet
     """
-    magnet_set._extract_filaments()
-    magnet_set._set_average_radial_distance()
-    magnet_set._set_filtered_filaments()
+    magnet_set._instantiate_coils()
+    magnet_set._compute_radial_distance_data()
+    magnet_set._filter_coils()
 
-    filtered_filaments = magnet_set.filtered_filaments
+    filtered_filaments = np.array(
+        [coil.coords for coil in magnet_set.magnet_coils]
+    )
     filaments = reorder_filaments(filtered_filaments)
 
     return filaments

--- a/parastell/radial_distance_utils.py
+++ b/parastell/radial_distance_utils.py
@@ -106,9 +106,7 @@ def get_reordered_filaments(magnet_set):
     """
     Convenience function to get the reordered filament data from a magnet
     """
-    magnet_set._instantiate_coils()
-    magnet_set._compute_radial_distance_data()
-    magnet_set._filter_coils()
+    magnet_set.populate_magnet_coils()
 
     filtered_filaments = np.array(
         [coil.coords for coil in magnet_set.magnet_coils]

--- a/tests/test_magnet_coils.py
+++ b/tests/test_magnet_coils.py
@@ -42,16 +42,16 @@ def test_magnet_construction(coil_set):
     thickness_exp = 50.0
     toroidal_extent_exp = np.deg2rad(90.0)
     max_cs_len_exp = 50.0
-    average_radial_distance_exp = 1028.5044183872055
+    average_radial_distance_exp = 1023.7170384211436
     max_radial_distance_exp = 1646.3258131460148
-    len_filaments_exp = 1
-    len_coords_exp = 14
+    len_coils_exp = 1
+    len_coords_exp = 129
 
     remove_files()
 
     coil_set.build_magnet_coils()
 
-    assert len(coil_set.filament_coords) == len_filaments_exp
+    assert len(coil_set.magnet_coils) == len_coils_exp
     assert coil_set.width == width_exp
     assert coil_set.thickness == thickness_exp
     assert coil_set.toroidal_extent == toroidal_extent_exp

--- a/tests/test_magnet_coils.py
+++ b/tests/test_magnet_coils.py
@@ -49,7 +49,7 @@ def test_magnet_construction(coil_set):
 
     remove_files()
 
-    coil_set.build_magnet_coils()
+    coil_set.populate_magnet_coils()
 
     assert len(coil_set.magnet_coils) == len_coils_exp
     assert coil_set.width == width_exp
@@ -69,6 +69,7 @@ def test_magnet_exports(coil_set):
 
     remove_files()
 
+    coil_set.populate_magnet_coils()
     coil_set.build_magnet_coils()
     coil_set.export_step()
     assert Path("magnet_set.step").exists()


### PR DESCRIPTION
Streamlines and reorganizes use of filament coordinate data as follows:

- Instantiates a new `MagnetCoil` class object as filament coordinate data becomes available in the `MagnetSet._instantiate_coils` method (formerly named `MagnetSet._extract_filament_data`), rather than store all filament data separately (and redundantly) in the `MagnetSet` class.
- For the purpose of filtering coils based on toroidal angle, moves the check of whether each coil lies within the model's toroidal extent to the `check_coil_toroidal_extent` method of the `MagnetCoil` class, rather than the `_filter_coils` method of the `MagnetSet` class (formerly named `MagnetSet._filter_filaments`). The `MagnetCoil._check_coil_toroidal_extent` method is called by the `MagnetSet._filter_coils` method to subsequently perform the actual filtering.
- Modifies storage of filament coordinates in the `MagnetCoil` class such that all coordinates are stored, and only downsampled during actual CAD solid generation. Note that the downsampled coordinates are not stored as part of any class.

Closes #47
Closes #149 (via PR #152)