### PR TITLE
Radial distance utility hot fix

### DIFF
--- a/Examples/radial_build_distance_example.py
+++ b/Examples/radial_build_distance_example.py
@@ -1,29 +1,34 @@
 from parastell.radial_distance_utils import *
 
-coils_file = "coils_wistelld.txt"
-circ_cross_section = ["circle", 25]
+coils_file = "coils.example"
+width = 40.0
+thickness = 50.0
 toroidal_extent = 90.0
-vmec_file = "plasma_wistelld.nc"
+vmec_file = "wout_vmec.nc"
 vmec = read_vmec.VMECData(vmec_file)
 
 magnet_set = magnet_coils.MagnetSet(
-    coils_file, circ_cross_section, toroidal_extent
+    coils_file, width, thickness, toroidal_extent
 )
 
 reordered_filaments = get_reordered_filaments(magnet_set)
 
 build_magnet_surface(reordered_filaments)
 
-toroidal_angles = np.linspace(0, 90, 72)
-poloidal_angles = np.linspace(0, 360, 96)
+toroidal_angles = np.linspace(0, 90, num=4)
+poloidal_angles = np.linspace(0, 360, num=4)
 wall_s = 1.08
 
 radial_build_dict = {}
 
 radial_build = ivb.RadialBuild(
-    toroidal_angles, poloidal_angles, wall_s, radial_build_dict
+    toroidal_angles,
+    poloidal_angles,
+    wall_s,
+    radial_build_dict,
+    split_chamber=False,
 )
-build = ivb.InVesselBuild(vmec, radial_build, split_chamber=False)
+build = ivb.InVesselBuild(vmec, radial_build, num_ribs=72, num_rib_pts=96)
 build.populate_surfaces()
 build.calculate_loci()
 ribs = build.Surfaces["chamber"].Ribs

--- a/parastell/radial_distance_utils.py
+++ b/parastell/radial_distance_utils.py
@@ -94,7 +94,8 @@ def reorder_filaments(filaments):
             [reordered_filament, [reordered_filament[0]]]
         )
 
-        filaments[filament_index] = reordered_filament
+        if max_z_index != 0:
+            filaments[filament_index] = reordered_filament
 
     filaments = sort_filaments_toroidally(filaments)
 
@@ -105,11 +106,13 @@ def get_reordered_filaments(magnet_set):
     """
     Convenience function to get the reordered filament data from a magnet
     """
-    magnet_set._extract_filaments()
-    magnet_set._set_average_radial_distance()
-    magnet_set._set_filtered_filaments()
+    magnet_set._instantiate_coils()
+    magnet_set._compute_radial_distance_data()
+    magnet_set._filter_coils()
 
-    filtered_filaments = magnet_set.filtered_filaments
+    filtered_filaments = np.array(
+        [coil.coords for coil in magnet_set.magnet_coils]
+    )
     filaments = reorder_filaments(filtered_filaments)
 
     return filaments

--- a/parastell/radial_distance_utils.py
+++ b/parastell/radial_distance_utils.py
@@ -90,12 +90,12 @@ def reorder_filaments(filaments):
             reordered_filament = np.flip(reordered_filament, axis=0)
 
         # ensure filament is a closed loop
-        reordered_filament = np.concatenate(
-            [reordered_filament, [reordered_filament[0]]]
-        )
-
         if max_z_index != 0:
-            filaments[filament_index] = reordered_filament
+            reordered_filament = np.concatenate(
+                [reordered_filament, [reordered_filament[0]]]
+            )
+
+        filaments[filament_index] = reordered_filament
 
     filaments = sort_filaments_toroidally(filaments)
 


### PR DESCRIPTION
This is a relatively concentrated hot fix that updates the radial distance utility to reflect recent changes to the syntax of the magnet workflow. Changes include:

- Syntax updates in the `radial_distance_utils.get_reordered_filaments` function.
- A condition added to the `radial_distance_utils.reorder_filaments` function to better address edge cases encountered during testing.
- Modifications to the example script
    - Reflect changes to the `MagnetSet` class
    - Reference input files actually present in the `Examples` directory
    - Modify the `RadialBuild` and `InVesselBuild` class instantiations to reflect proper use.

The scope of this PR was kept relatively focused but additional changes should be made to the radial distance utility in subsequent PRs to better leverage modifications to the `MagnetSet` and `MagnetCoil` classes from PRs #139 and #151.

Note that this PR depends on the `filament-data-refactor` branch, and therefore must be merged into that branch or must wait for PR #151 to be merged into `main` should we want this PR to do the same.

Closes #149