### PR TITLE
use UWUW vacuum boundary condition for NWL example

### DIFF
--- a/Examples/nwl_geom_example.py
+++ b/Examples/nwl_geom_example.py
@@ -1,9 +1,6 @@
 from pathlib import Path
-
-import numpy as np
-
 import parastell.parastell as ps
-
+from parastell.cubit_io import tag_surface_legacy
 
 # Define directory to export all output files to
 export_dir = ""
@@ -50,4 +47,5 @@ for tet in strengths:
 
 # Export DAGMC neutronics H5M file
 stellarator.build_cubit_model(skip_imprint=True, legacy_faceting=True)
+tag_surface_legacy(1, "vacuum")
 stellarator.export_dagmc(filename="nwl_geom", export_dir=export_dir)

--- a/parastell/cubit_io.py
+++ b/parastell/cubit_io.py
@@ -135,6 +135,17 @@ def export_dagmc_cubit_legacy(
     cubit.cmd(f'export dagmc "{export_path}" {tol_str} make_watertight')
 
 
+def tag_surface_legacy(surface_id, tag):
+    """Applies a boundary condition to a surface in cubit following UWUW
+    syntax.
+
+    Arguments:
+        surface_id (int): Surface to tag
+        tag (str): boundary type
+    """
+    cubit.cmd(f'group "boundary:{tag}" add surf {surface_id}')
+
+
 def export_dagmc_cubit_native(
     anisotropic_ratio=100.0,
     deviation_angle=5.0,

--- a/parastell/nwl_utils.py
+++ b/parastell/nwl_utils.py
@@ -32,7 +32,9 @@ def extract_ss(ss_file):
 
 
 def nwl_transport(dagmc_geom, source_mesh, tor_ext, ss_file, num_parts):
-    """Performs neutron transport on first wall geometry via OpenMC.
+    """Performs neutron transport on first wall geometry via OpenMC. The
+    first wall must be tagged as a vacuum boundary during the creating of the
+    DAGMC geometry.
 
     Arguments:
         dagmc_geom (str): path to DAGMC geometry file.
@@ -51,7 +53,6 @@ def nwl_transport(dagmc_geom, source_mesh, tor_ext, ss_file, num_parts):
     dag_univ = openmc.DAGMCUniverse(dagmc_geom, auto_geom_ids=False)
 
     # Define problem boundaries
-    vac_surf = openmc.Sphere(r=10000, surface_id=9999, boundary_type="vacuum")
     per_init = openmc.YPlane(boundary_type="periodic", surface_id=9991)
     per_fin = openmc.Plane(
         a=np.sin(tor_ext),
@@ -63,7 +64,7 @@ def nwl_transport(dagmc_geom, source_mesh, tor_ext, ss_file, num_parts):
     )
 
     # Define first period of geometry
-    region = -vac_surf & +per_init & +per_fin
+    region = +per_init & +per_fin
     period = openmc.Cell(cell_id=9996, region=region, fill=dag_univ)
     geometry = openmc.Geometry([period])
     model.geometry = geometry
@@ -87,7 +88,7 @@ def nwl_transport(dagmc_geom, source_mesh, tor_ext, ss_file, num_parts):
     # Track surface crossings
     settings.surf_source_write = {
         "surface_ids": [1],
-        "max_particles": num_parts,
+        "max_particles": num_parts * 2,
     }
 
     model.settings = settings


### PR DESCRIPTION
Updates the example to apply a vacuum boundary condition prior to DAGMC export. Fixes #155. Tried to make this as minimal of a fix as possible