### PR TITLE
Add tags to docker images to prevent branches from overwriting Parastell docker images

### DIFF
--- a/.github/workflows/docker_publish.yml
+++ b/.github/workflows/docker_publish.yml
@@ -39,8 +39,8 @@ jobs:
       - name: Add extra tag if NOT on the main branch
         if: github.ref_name != 'main'
         run: |
-          echo "EXTRA_TAG=-$github.ref_name" >> $GITHUB_ENV
-          echo "EXTRA_TAG_CI=:$github.ref_name" >> $GITHUB_ENV
+          echo "EXTRA_TAG=-${{ github.ref_name }}" >> $GITHUB_ENV
+          echo "EXTRA_TAG_CI=:${{ github.ref_name }}" >> $GITHUB_ENV
 
       - id: output_tag
         run: echo "image_tag=$EXTRA_TAG_CI" >> $GITHUB_OUTPUT

--- a/.github/workflows/docker_publish.yml
+++ b/.github/workflows/docker_publish.yml
@@ -9,11 +9,19 @@ on:
       - '.github/workflows/docker_publish.yml'
       - 'environment.yml'
 
+env:
+  EXTRA_TAG: ""
+  EXTRA_TAG_CI: ""
+
 jobs:
   build-dependency-img:
     runs-on: ubuntu-latest
 
     name: Install Dependencies
+
+    outputs: 
+      image_tag: ${{ steps.output_tag.outputs.image_tag }}
+
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -28,21 +36,30 @@ jobs:
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Add extra tag if NOT on the main branch
+        if: github.ref_name != 'main'
+        run: |
+          echo "EXTRA_TAG=-$github.ref_name" >> $GITHUB_ENV
+          echo "EXTRA_TAG_CI=:$github.ref_name" >> $GITHUB_ENV
+
+      - id: output_tag
+        run: echo "image_tag=$EXTRA_TAG_CI" >> $GITHUB_OUTPUT
+
       - name: Build and push ParaStell Docker image
         id: build-parastell
         uses: docker/build-push-action@v5
         with:
-          cache-from: type=registry,ref=ghcr.io/${{ github.repository_owner }}/parastell:ci-layer-cache
-          cache-to: type=registry,ref=ghcr.io/${{ github.repository_owner }}/parastell:ci-layer-cache,mode=max
+          cache-from: type=registry,ref=ghcr.io/svalinn/parastell:ci-layer-cache${{ env.EXTRA_TAG }}
+          cache-to: type=registry,ref=ghcr.io/svalinn/parastell:ci-layer-cache${{ env.EXTRA_TAG }},mode=max
           file: Dockerfile
           push: true
           target: parastell-deps
-          tags: ghcr.io/${{ github.repository_owner }}/parastell-ci
+          tags: ghcr.io/svalinn/parastell-ci${{ env.EXTRA_TAG_CI }}
 
   test-dependency-img:
     needs: build-dependency-img
     runs-on: ubuntu-latest
-    container: ghcr.io/${{ github.repository_owner }}/parastell-ci
+    container: ghcr.io/svalinn/parastell-ci${{ needs.build-dependency-img.outputs.image_tag }}
 
     name: Test CI Image
     steps:

--- a/.github/workflows/docker_publish.yml
+++ b/.github/workflows/docker_publish.yml
@@ -32,17 +32,17 @@ jobs:
         id: build-parastell
         uses: docker/build-push-action@v5
         with:
-          cache-from: type=registry,ref=ghcr.io/svalinn/parastell:ci-layer-cache
-          cache-to: type=registry,ref=ghcr.io/svalinn/parastell:ci-layer-cache,mode=max
+          cache-from: type=registry,ref=ghcr.io/${{ github.repository_owner }}/parastell:ci-layer-cache
+          cache-to: type=registry,ref=ghcr.io/${{ github.repository_owner }}/parastell:ci-layer-cache,mode=max
           file: Dockerfile
           push: true
           target: parastell-deps
-          tags: ghcr.io/svalinn/parastell-ci
+          tags: ghcr.io/${{ github.repository_owner }}/parastell-ci
 
   test-dependency-img:
     needs: build-dependency-img
     runs-on: ubuntu-latest
-    container: ghcr.io/svalinn/parastell-ci
+    container: ghcr.io/${{ github.repository_owner }}/parastell-ci
 
     name: Test CI Image
     steps:


### PR DESCRIPTION
Currently, `docker_publish.yml` pulls and pushes docker images to a hardcoded image name and tag, which is the official parastell docker image. This can be problematic if a branch changes something and pushes a docker image that doesn't work.

I have changed `docker_publish.yml` to now pull and push docker images to the same image name, but with a tag based on the branch name if the branch is not `main`. This way, contributors can make changes without worrying about breaking the official image. 

This PR is a continuation of #154, with the difference being that this PR was pushed to a branch in the repo owned by `svalinn` instead of a branch in my forked repo. 