### PR TITLE
import ivb components first so vol ids start at 1

### DIFF
--- a/parastell/parastell.py
+++ b/parastell/parastell.py
@@ -387,11 +387,11 @@ class Stellarator(object):
         else:
             cubit_io.init_cubit()
 
-        if self.magnet_set:
-            self._import_magnets_step()
-
         if self.invessel_build:
             self._import_ivb_step()
+
+        if self.magnet_set:
+            self._import_magnets_step()
 
         if skip_imprint:
             self.invessel_build.merge_layer_surfaces()


### PR DESCRIPTION
It is convenient to have the cell ids start at 1 with the plasma chamber, makes it more obvious which cells will be which in openmc