### PR TITLE
Use list comprehension for shift the theta coordinate from 0 to 2pi

### DIFF
--- a/parastell/invessel_build.py
+++ b/parastell/invessel_build.py
@@ -827,7 +827,8 @@ def generate_invessel_build():
         invessel_build_dict["poloidal_angles"],
         invessel_build_dict["wall_s"],
         invessel_build_dict["radial_build"],
-        logger=logger**invessel_build_dict,
+        logger=logger,
+        **invessel_build_dict,
     )
 
     invessel_build = InVesselBuild(

--- a/parastell/nwl_utils.py
+++ b/parastell/nwl_utils.py
@@ -187,7 +187,9 @@ def flux_coords(plas_eq, wall_s, coords, num_threads):
             for theta_coord in theta_coord_chunk
         ]
     # Ensures theta_coords are all positive (add 360 degrees where needed)
-    theta_coords = (theta_coords + 2 * np.pi) % 2 * np.pi
+    theta_coords = [
+        (theta_coord + 2 * np.pi) % 2 * np.pi for theta_coord in theta_coords
+    ]
 
     return phi_coords.tolist(), theta_coords
 

--- a/parastell/nwl_utils.py
+++ b/parastell/nwl_utils.py
@@ -145,7 +145,7 @@ def find_coords(data):
             bounds=[(-np.pi, np.pi)],
             args=(vmec, wall_s, coords[0], coords[1]),
         )
-        thetas.append(theta.x[0])
+        thetas.append((theta.x[0] + 2 * np.pi) % (2 * np.pi))
     return thetas
 
 
@@ -186,10 +186,6 @@ def flux_coords(plas_eq, wall_s, coords, num_threads):
             for theta_coord_chunk in theta_coord_chunks
             for theta_coord in theta_coord_chunk
         ]
-    # Ensures theta_coords are all positive (add 360 degrees where needed)
-    theta_coords = [
-        (theta_coord + 2 * np.pi) % 2 * np.pi for theta_coord in theta_coords
-    ]
 
     return phi_coords.tolist(), theta_coords
 

--- a/parastell/nwl_utils.py
+++ b/parastell/nwl_utils.py
@@ -145,6 +145,7 @@ def find_coords(data):
             bounds=[(-np.pi, np.pi)],
             args=(vmec, wall_s, coords[0], coords[1]),
         )
+        # remap from [-pi,pi] to [0, 2pi] to match parastell's angle convention
         thetas.append((theta.x[0] + 2 * np.pi) % (2 * np.pi))
     return thetas
 


### PR DESCRIPTION
I experienced an error with nwl_utils.py as currently written, since theta_coords is a list. This approach, or changing theta_coords to a numpy array will alleviate that error.

Fixed a missing comma in invessel_build.py