### PR TITLE
Modify and update magnet meshing workflow

### DIFF
--- a/parastell/cubit_io.py
+++ b/parastell/cubit_io.py
@@ -97,6 +97,10 @@ def export_mesh_cubit(filename, export_dir=""):
     subprocess.run(f"mbconvert {exo_path} {h5m_path}", shell=True)
     Path.unlink(exo_path)
 
+    # Delete any meshes present to prevent inclusion in future Cubit mesh
+    # exports
+    cubit.cmd(f"delete mesh volume all propagate")
+
 
 def export_dagmc_cubit_legacy(
     faceting_tolerance=None,
@@ -177,3 +181,7 @@ def export_dagmc_cubit_native(
 
     export_path = Path(export_dir) / Path(filename).with_suffix(".h5m")
     cubit.cmd(f'export cf_dagmc "{export_path}" overwrite')
+
+    # Delete any meshes present to prevent inclusion in future Cubit mesh
+    # exports
+    cubit.cmd(f"delete mesh volume all propagate")

--- a/parastell/cubit_io.py
+++ b/parastell/cubit_io.py
@@ -79,7 +79,7 @@ def export_cub5(filename, export_dir=""):
     cubit.cmd(f'save cub5 "{export_path}" overwrite')
 
 
-def export_mesh_cubit(filename, export_dir=""):
+def export_mesh_cubit(filename, export_dir="", delete_upon_export=True):
     """Exports Cubit mesh to H5M file format, first exporting to Exodus format
     via Coreform Cubit and converting to H5M via MOAB.
 
@@ -87,6 +87,8 @@ def export_mesh_cubit(filename, export_dir=""):
         filename (str): name of H5M output file, excluding '.h5m' extension.
         export_dir (str): directory to which to export the H5M output file
             (defaults to empty string).
+        delete_upon_export (bool): delete the mesh from the Cubit instance
+            after exporting. Prevents inclusion of mesh in future exports.
     """
     init_cubit()
 
@@ -99,7 +101,8 @@ def export_mesh_cubit(filename, export_dir=""):
 
     # Delete any meshes present to prevent inclusion in future Cubit mesh
     # exports
-    cubit.cmd(f"delete mesh volume all propagate")
+    if delete_upon_export:
+        cubit.cmd(f"delete mesh volume all propagate")
 
 
 def export_dagmc_cubit_legacy(
@@ -155,6 +158,7 @@ def export_dagmc_cubit_native(
     deviation_angle=5.0,
     filename="dagmc",
     export_dir="",
+    delete_upon_export=True,
 ):
     """Exports DAGMC neutronics H5M file of ParaStell components via native
     faceting method for Coreform Cubit.
@@ -169,6 +173,8 @@ def export_dagmc_cubit_native(
             (defaults to 'dagmc').
         export_dir (str): directory to which to export the DAGMC output file
             (defaults to empty string).
+        delete_upon_export (bool): delete the mesh from the Cubit instance
+            after exporting. Prevents inclusion of mesh in future exports.
     """
     init_cubit()
 
@@ -184,4 +190,5 @@ def export_dagmc_cubit_native(
 
     # Delete any meshes present to prevent inclusion in future Cubit mesh
     # exports
-    cubit.cmd(f"delete mesh volume all propagate")
+    if delete_upon_export:
+        cubit.cmd(f"delete mesh volume all propagate")

--- a/parastell/invessel_build.py
+++ b/parastell/invessel_build.py
@@ -10,6 +10,7 @@ import cad_to_dagmc
 import pystell.read_vmec as read_vmec
 
 from . import log
+from . import cubit_io
 from .utils import (
     normalize,
     expand_list,
@@ -291,6 +292,12 @@ class InVesselBuild(object):
                     f"merge surface {inner_surface_id} {prev_outer_surface_id}"
                 )
                 prev_outer_surface_id = outer_surface_id
+
+    def import_step_cubit(self):
+        """Imports STEP files from in-vessel build into Coreform Cubit."""
+        for name, data in self.radial_build.radial_build.items():
+            vol_id = cubit_io.import_step_cubit(name, self.export_dir)
+            data["vol_id"] = vol_id
 
     def export_step(self, export_dir=""):
         """Export CAD solids as STEP files via CadQuery.

--- a/parastell/magnet_coils.py
+++ b/parastell/magnet_coils.py
@@ -248,7 +248,7 @@ class MagnetSet(object):
             self.step_filename, self.export_dir
         )
 
-        self.volume_ids = [range(first_vol_id, last_vol_id + 1)]
+        self.volume_ids = list(range(first_vol_id, last_vol_id + 1))
 
     def export_step(self, step_filename="magnet_set", export_dir=""):
         """Export CAD solids as a STEP file via CadQuery.

--- a/parastell/magnet_coils.py
+++ b/parastell/magnet_coils.py
@@ -240,10 +240,9 @@ class MagnetSet(object):
 
     def import_step_cubit(self):
         """Import STEP file for magnet set into Coreform Cubit."""
+        first_vol_id = 1
         if cubit_io.initialized:
-            first_vol_id = cubit.get_last_id("volume") + 1
-        else:
-            first_vol_id = 1
+            first_vol_id += cubit.get_last_id("volume")
 
         last_vol_id = cubit_io.import_step_cubit(
             self.step_filename, self.export_dir

--- a/parastell/magnet_coils.py
+++ b/parastell/magnet_coils.py
@@ -313,10 +313,6 @@ class MagnetSet(object):
             filename=mesh_filename, export_dir=export_dir
         )
 
-        # Delete magnet mesh to prevent inclusion in future Cubit mesh exports
-        volume_ids_str = " ".join(str(id) for id in self.volume_ids)
-        cubit.cmd(f"delete mesh volume {volume_ids_str} propagate")
-
     def sort_coils_toroidally(self):
         """Reorders list of coils by toroidal angle on range [-pi, pi].
 

--- a/parastell/magnet_coils.py
+++ b/parastell/magnet_coils.py
@@ -248,7 +248,7 @@ class MagnetSet(object):
             self.step_filename, self.export_dir
         )
 
-        self.volume_ids = range(first_vol_id, last_vol_id + 1)
+        self.volume_ids = [range(first_vol_id, last_vol_id + 1)]
 
     def export_step(self, step_filename="magnet_set", export_dir=""):
         """Export CAD solids as a STEP file via CadQuery.

--- a/tests/test_magnet_coils.py
+++ b/tests/test_magnet_coils.py
@@ -67,7 +67,7 @@ def test_magnet_construction(coil_set):
 
 def test_magnet_exports(coil_set):
 
-    volume_ids_exp = range(1, 2)
+    volume_ids_exp = list(range(1, 2))
 
     remove_files()
 

--- a/tests/test_magnet_coils.py
+++ b/tests/test_magnet_coils.py
@@ -67,6 +67,8 @@ def test_magnet_construction(coil_set):
 
 def test_magnet_exports(coil_set):
 
+    volume_ids_exp = range(1, 2)
+
     remove_files()
 
     coil_set.populate_magnet_coils()
@@ -75,6 +77,8 @@ def test_magnet_exports(coil_set):
     assert Path("magnet_set.step").exists()
 
     coil_set.mesh_magnets()
+    assert coil_set.volume_ids == volume_ids_exp
+
     coil_set.export_mesh()
     assert Path("magnet_mesh.h5m").exists()
 

--- a/tests/test_parastell.py
+++ b/tests/test_parastell.py
@@ -114,9 +114,27 @@ def test_parastell(stellarator):
 
     assert Path(filename_exp).with_suffix(".h5m").exists()
 
+    chamber_volume_id_exp = 1
+    component_volume_id_exp = 2
+    magnet_volume_ids_exp = range(3, 4)
     filename_exp = "dagmc"
 
     stellarator.build_cubit_model()
+
+    assert (
+        stellarator.invessel_build.radial_build.radial_build["chamber"][
+            "vol_id"
+        ]
+        == chamber_volume_id_exp
+    )
+    assert (
+        stellarator.invessel_build.radial_build.radial_build[
+            component_name_exp
+        ]["vol_id"]
+        == component_volume_id_exp
+    )
+    assert stellarator.magnet_set.volume_ids == magnet_volume_ids_exp
+
     stellarator.export_dagmc(filename=filename_exp)
     stellarator.export_cub5(filename=filename_exp)
 

--- a/tests/test_parastell.py
+++ b/tests/test_parastell.py
@@ -116,7 +116,7 @@ def test_parastell(stellarator):
 
     chamber_volume_id_exp = 1
     component_volume_id_exp = 2
-    magnet_volume_ids_exp = range(3, 4)
+    magnet_volume_ids_exp = list(range(3, 4))
     filename_exp = "dagmc"
 
     stellarator.build_cubit_model()


### PR DESCRIPTION
Makes the following changes in an effort to improve the magnet meshing workflow, as well as fix some oversights in a previous PR:

- Changes magnet meshing algorithm in Cubit to one that gives greater control over mesh parameters, adding additional meshing arguments
- Puts checks in magnet meshing workflow to determine whether magnets have already been imported into Cubit, and if not, to properly set volume IDs
- Modifies magnet meshing call in Stellarator class to incorporate additional meshing arguments
- Moves magnet and IVB STEP imports in Cubit to corresponding objects
- Updates magnet STEP import in Cubit to properly set volume IDs, reflecting recent changes in STEP import order
- Updates tests to check that volume IDs are properly set