### PR TITLE
Fix MOAB canonical ordering during element splitting

### DIFF
--- a/parastell/source_mesh.py
+++ b/parastell/source_mesh.py
@@ -356,12 +356,18 @@ class SourceMesh(object):
         ]
 
         # Define MOAB canonical ordering of hexahedron vertex indices
+        # Ordering follows right hand rule such that the fingers curl around
+        # one side of the tetrahedron and the thumb points to the remaining
+        # vertex. The vertices are ordered such that those on the side are
+        # first, ordered clockwise relative to the thumb, followed by the
+        # remaining vertex at the end of the thumb.
+        # See Moreno, Bader, Wilson 2024 for hexahedron splitting
         hex_canon_ids = [
-            [idx_list[0], idx_list[3], idx_list[1], idx_list[4]],
-            [idx_list[7], idx_list[4], idx_list[6], idx_list[3]],
-            [idx_list[2], idx_list[1], idx_list[3], idx_list[6]],
-            [idx_list[5], idx_list[6], idx_list[4], idx_list[1]],
-            [idx_list[3], idx_list[1], idx_list[4], idx_list[6]],
+            [idx_list[0], idx_list[2], idx_list[1], idx_list[5]],
+            [idx_list[0], idx_list[3], idx_list[2], idx_list[7]],
+            [idx_list[0], idx_list[7], idx_list[5], idx_list[4]],
+            [idx_list[7], idx_list[2], idx_list[5], idx_list[6]],
+            [idx_list[0], idx_list[2], idx_list[5], idx_list[7]],
         ]
 
         for vertex_ids in hex_canon_ids:
@@ -395,10 +401,16 @@ class SourceMesh(object):
         ]
 
         # Define MOAB canonical ordering of wedge vertex indices
+        # Ordering follows right hand rule such that the fingers curl around
+        # one side of the tetrahedron and the thumb points to the remaining
+        # vertex. The vertices are ordered such that those on the side are
+        # first, ordered clockwise relative to the thumb, followed by the
+        # remaining vertex at the end of the thumb.
+        # See Moreno, Bader, Wilson 2024 for wedge splitting
         wedge_canon_ids = [
-            [idx_list[1], idx_list[2], idx_list[4], idx_list[0]],
-            [idx_list[5], idx_list[4], idx_list[2], idx_list[3]],
-            [idx_list[0], idx_list[2], idx_list[4], idx_list[3]],
+            [idx_list[0], idx_list[2], idx_list[1], idx_list[3]],
+            [idx_list[3], idx_list[2], idx_list[4], idx_list[5]],
+            [idx_list[3], idx_list[2], idx_list[1], idx_list[4]],
         ]
 
         for vertex_ids in wedge_canon_ids:

--- a/tests/test_source_mesh.py
+++ b/tests/test_source_mesh.py
@@ -22,7 +22,9 @@ def source_mesh():
 
     vmec_obj = read_vmec.VMECData(vmec_file)
 
-    mesh_size = (4, 8, 4)
+    # Set mesh size to minimum that maintains element aspect ratios that do not
+    # result in negative volumes
+    mesh_size = (3, 31, 31)
     toroidal_extent = 90.0
 
     source_mesh_obj = sm.SourceMesh(vmec_obj, mesh_size, toroidal_extent)
@@ -64,6 +66,20 @@ def test_vertices(source_mesh):
     assert source_mesh.coords.shape == (num_verts_exp, 3)
     assert source_mesh.coords_s.shape == (num_verts_exp,)
     assert len(source_mesh.verts) == num_verts_exp
+
+    remove_files()
+
+
+def test_mesh_generation(source_mesh):
+
+    count_neg_vols_exp = 0
+
+    remove_files()
+
+    source_mesh.create_vertices()
+    source_mesh.create_mesh()
+
+    assert len([i for i in source_mesh.volumes if i < 0]) == count_neg_vols_exp
 
     remove_files()
 

--- a/tests/test_source_mesh.py
+++ b/tests/test_source_mesh.py
@@ -34,9 +34,9 @@ def source_mesh():
 
 def test_mesh_basics(source_mesh):
 
-    num_s_exp = 4
-    num_theta_exp = 8
-    num_phi_exp = 4
+    num_s_exp = 3
+    num_theta_exp = 31
+    num_phi_exp = 31
     tor_ext_exp = 90.0
     scale_exp = 100
 
@@ -53,9 +53,9 @@ def test_mesh_basics(source_mesh):
 
 def test_vertices(source_mesh):
 
-    num_s = 4
-    num_theta = 8
-    num_phi = 4
+    num_s = 3
+    num_theta = 31
+    num_phi = 31
 
     num_verts_exp = num_phi * ((num_s - 1) * (num_theta - 1) + 1)
 

--- a/tests/test_source_mesh.py
+++ b/tests/test_source_mesh.py
@@ -24,7 +24,7 @@ def source_mesh():
 
     # Set mesh size to minimum that maintains element aspect ratios that do not
     # result in negative volumes
-    mesh_size = (3, 31, 31)
+    mesh_size = (6, 41, 51)
     toroidal_extent = 90.0
 
     source_mesh_obj = sm.SourceMesh(vmec_obj, mesh_size, toroidal_extent)
@@ -34,9 +34,9 @@ def source_mesh():
 
 def test_mesh_basics(source_mesh):
 
-    num_s_exp = 3
-    num_theta_exp = 31
-    num_phi_exp = 31
+    num_s_exp = 6
+    num_theta_exp = 41
+    num_phi_exp = 51
     tor_ext_exp = 90.0
     scale_exp = 100
 
@@ -53,9 +53,9 @@ def test_mesh_basics(source_mesh):
 
 def test_vertices(source_mesh):
 
-    num_s = 3
-    num_theta = 31
-    num_phi = 31
+    num_s = 6
+    num_theta = 41
+    num_phi = 51
 
     num_verts_exp = num_phi * ((num_s - 1) * (num_theta - 1) + 1)
 
@@ -72,9 +72,9 @@ def test_vertices(source_mesh):
 
 def test_mesh_generation(source_mesh):
 
-    num_s = 3
-    num_theta = 31
-    num_phi = 31
+    num_s = 6
+    num_theta = 41
+    num_phi = 51
 
     tets_per_wedge = 3
     tets_per_hex = 5

--- a/tests/test_source_mesh.py
+++ b/tests/test_source_mesh.py
@@ -72,14 +72,25 @@ def test_vertices(source_mesh):
 
 def test_mesh_generation(source_mesh):
 
-    count_neg_vols_exp = 0
+    num_s = 3
+    num_theta = 31
+    num_phi = 31
+
+    tets_per_wedge = 3
+    tets_per_hex = 5
+
+    num_elements_exp = tets_per_wedge * (num_theta - 1) * (
+        num_phi - 1
+    ) + tets_per_hex * (num_s - 2) * (num_theta - 1) * (num_phi - 1)
+    num_neg_vols_exp = 0
 
     remove_files()
 
     source_mesh.create_vertices()
     source_mesh.create_mesh()
 
-    assert len([i for i in source_mesh.volumes if i < 0]) == count_neg_vols_exp
+    assert len(source_mesh.volumes) == num_elements_exp
+    assert len([i for i in source_mesh.volumes if i < 0]) == num_neg_vols_exp
 
     remove_files()
 


### PR DESCRIPTION
Corrects implementation of MOAB canonical ordering. Changes are as follows:

- Changes MOAB canonical ordering for both wedges and hexahedra to coincide with element splitting shown in ParaStell publication (Moreno, Bader, Wilson, 2024)
- Adds documentation explaining MOAB canonical ordering for posterity

Closes #166 