### PR TITLE
Use spline surface fitting for in-vessel component CAD generation

### DIFF
--- a/parastell/invessel_build.py
+++ b/parastell/invessel_build.py
@@ -316,11 +316,21 @@ class InVesselBuild(object):
             )
             cq.exporters.export(component, str(export_path))
 
-    def export_cad_to_dagmc(self, dagmc_filename="dagmc", export_dir=""):
+    def export_cad_to_dagmc(
+        self,
+        min_mesh_size=1,
+        max_mesh_size=5,
+        dagmc_filename="dagmc",
+        export_dir="",
+    ):
         """Exports DAGMC neutronics H5M file of ParaStell in-vessel components
         via CAD-to-DAGMC.
 
         Arguments:
+            min_mesh_size (float): minimum size of mesh elements [cm] (defaults
+                to 1.0).
+            max_mesh_size (float): maximum size of mesh elements [cm] (defaults
+                to 5.0).
             dagmc_filename (str): name of DAGMC output file, excluding '.h5m'
                 extension (optional, defaults to 'dagmc').
             export_dir (str): directory to which to export the DAGMC output file
@@ -344,7 +354,11 @@ class InVesselBuild(object):
             ".h5m"
         )
 
-        model.export_dagmc_h5m_file(filename=str(export_path))
+        model.export_dagmc_h5m_file(
+            filename=str(export_path),
+            min_mesh_size=min_mesh_size,
+            max_mesh_size=max_mesh_size,
+        )
 
 
 class Surface(object):

--- a/parastell/invessel_build.py
+++ b/parastell/invessel_build.py
@@ -492,12 +492,13 @@ class Surface(object):
         set of points computed by calculate_loci.
         """
         if not self.surface:
-            vectors = [
-                [cq.Vector(tuple(pt)) for pt in profile]
-                for profile in self.surface_loci
-            ]
             if self.transpose_fit:
-                vectors = list(map(list, zip(*vectors)))
+                self.surface_loci = np.transpose(self.surface_loci, (1, 0, 2))
+
+            vectors = [
+                [cq.Vector(tuple(pt)) for pt in grid_row]
+                for grid_row in self.surface_loci
+            ]
 
             self.surface = cq.Face.makeSplineApprox(
                 vectors,

--- a/parastell/parastell.py
+++ b/parastell/parastell.py
@@ -137,17 +137,19 @@ class Stellarator(object):
             sol_mat_tag (str): alternate DAGMC material tag to use for
                 scrape-off layer. If none is supplied, 'Vacuum' will be used
                 (defaults to None).
-            repeat (int): number of times to repeat build segment for full model
-                (defaults to 0).
-            num_ribs (int): total number of ribs over which to loft for each
-                build segment (defaults to 61). Ribs are set at toroidal angles
-                interpolated between those specified in 'toroidal_angles' if
-                this value is greater than the number of entries in
-                'toroidal_angles'.
-            num_rib_pts (int): total number of points defining each rib spline
-                (defaults to 61). Points are set at poloidal angles interpolated
-                between those specified in 'poloidal_angles' if this value is
-                greater than the number of entries in 'poloidal_angles'.
+            toroidal_grid_size (int): number of toroidal angle grid points
+                defining point clouds over which spline surfaces are fit. If
+                this value is greater than the length of "toroidal_angles",
+                additional grid points are set at toroidal angles interpolated
+                between those specified in "toroidal_angles".
+            poloidal_grid_size (int): number of poloidal angle grid points
+                defining point clouds over which spline surfaces are fit. If
+                this value is greater than the length of "poloidal_angles",
+                additional grid points are set at poloidal angles interpolated
+                between those specified in "poloidal_angles".
+            transpose_fit (bool): flag to indicate whether the 2-D iterable of
+                points through which each component's spline surface is fit
+                should be transposed. Can sometimes fix errant CAD generation.
             scale (float): a scaling factor between the units of VMEC and [cm]
                 (defaults to m2cm = 100).
         """

--- a/parastell/utils.py
+++ b/parastell/utils.py
@@ -138,7 +138,7 @@ def filter_kwargs(
 
 
 def normalize(vec_list):
-    """Normalizes an array. Input must be a 1-D, 2-D, or 3-D array.
+    """Normalizes a NumPy array. Input must be a 1-D, 2-D, or 3-D array.
 
     Arguments:
         vec_list (iterable of float): array to be normalized.

--- a/parastell/utils.py
+++ b/parastell/utils.py
@@ -138,21 +138,22 @@ def filter_kwargs(
 
 
 def normalize(vec_list):
-    """Normalizes a set of vectors.
+    """Normalizes an array. Input must be a 1-D, 2-D, or 3-D array.
 
     Arguments:
-        vec_list (1 or 2D np array): single 1D vector or array of 1D vectors
-            to be normalized
+        vec_list (iterable of float): array to be normalized.
+
     Returns:
-        vec_list (np array of same shape as input): single 1D normalized vector
-            or array of normalized 1D vectors
+        vec_list (iterable of float): normalized array.
     """
     if len(vec_list.shape) == 1:
         return vec_list / np.linalg.norm(vec_list)
     elif len(vec_list.shape) == 2:
         return vec_list / np.linalg.norm(vec_list, axis=1)[:, np.newaxis]
+    elif len(vec_list.shape) == 3:
+        return vec_list / np.linalg.norm(vec_list, axis=2)[:, :, np.newaxis]
     else:
-        print('Input "vec_list" must be 1-D or 2-D NumPy array')
+        print("Input must be a 1-D, 2-D, or 3-D array")
 
 
 def read_yaml_config(filename):

--- a/tests/test_invessel_build.py
+++ b/tests/test_invessel_build.py
@@ -2,12 +2,9 @@ from pathlib import Path
 
 import numpy as np
 import pytest
-
-# import this before read_vmec to deal with conflicting
-# dependencies correctly
-import parastell.invessel_build as ivb
-
 import pystell.read_vmec as read_vmec
+
+import parastell.invessel_build as ivb
 
 
 def remove_files():
@@ -52,7 +49,10 @@ def invessel_build(radial_build):
     toroidal_grid_size = 11
 
     ivb_obj = ivb.InVesselBuild(
-        vmec, radial_build, toroidal_grid_size=toroidal_grid_size
+        vmec,
+        radial_build,
+        toroidal_grid_size=toroidal_grid_size,
+        transpose_fit=True,
     )
 
     return ivb_obj

--- a/tests/test_invessel_build.py
+++ b/tests/test_invessel_build.py
@@ -49,9 +49,11 @@ def invessel_build(radial_build):
 
     vmec_file = Path("files_for_tests") / "wout_vmec.nc"
     vmec = read_vmec.VMECData(vmec_file)
-    num_ribs = 11
+    toroidal_grid_size = 11
 
-    ivb_obj = ivb.InVesselBuild(vmec, radial_build, num_ribs=num_ribs)
+    ivb_obj = ivb.InVesselBuild(
+        vmec, radial_build, toroidal_grid_size=toroidal_grid_size
+    )
 
     return ivb_obj
 
@@ -62,9 +64,8 @@ def test_ivb_basics(invessel_build):
     poloidal_angles_exp = [0.0, 120.0, 240.0, 360.0]
     num_components_exp = 2
     wall_s_exp = 1.08
-    repeat_exp = 0
-    num_ribs_exp = 11
-    num_rib_pts_exp = 67
+    toroidal_grid_size_exp = 11
+    poloidal_grid_size_exp = 61
     scale_exp = 100
     chamber_mat_tag_exp = "Vacuum"
 
@@ -87,9 +88,8 @@ def test_ivb_basics(invessel_build):
         invessel_build.radial_build.radial_build["chamber"]["mat_tag"]
         == chamber_mat_tag_exp
     )
-    assert invessel_build.repeat == repeat_exp
-    assert invessel_build.num_ribs == num_ribs_exp
-    assert invessel_build.num_rib_pts == num_rib_pts_exp
+    assert invessel_build.toroidal_grid_size == toroidal_grid_size_exp
+    assert invessel_build.poloidal_grid_size == poloidal_grid_size_exp
     assert invessel_build.scale == scale_exp
 
     remove_files()
@@ -106,11 +106,11 @@ def test_ivb_construction(invessel_build):
     invessel_build.calculate_loci()
     invessel_build.generate_components()
 
-    rib_loci = invessel_build.Surfaces["component"].get_loci()[0]
+    pt_loci = invessel_build.Surfaces["component"].surface_loci[0]
 
     assert len(invessel_build.Components) == num_components_exp
-    assert len(rib_loci[0]) == len_loci_pt_exp
-    assert isinstance(rib_loci[0][0], float)
+    assert len(pt_loci[0]) == len_loci_pt_exp
+    assert isinstance(pt_loci[0][0], float)
 
     remove_files()
 

--- a/tests/test_parastell.py
+++ b/tests/test_parastell.py
@@ -60,14 +60,14 @@ def test_parastell(stellarator):
             * 10
         }
     }
-    num_ribs = 11
+    toroidal_grid_size = 11
 
     stellarator.construct_invessel_build(
         toroidal_angles,
         poloidal_angles,
         wall_s,
         radial_build_dict,
-        num_ribs=num_ribs,
+        toroidal_grid_size=toroidal_grid_size,
     )
 
     chamber_filename_exp = Path("chamber").with_suffix(".step")


### PR DESCRIPTION
### Overview

Modifies the in-vessel component CAD generation workflow to use CadQuery’s spline surface fitting routine, instead of its lofting routine, to define the outer surfaces of each in-vessel component (IVC). The benefits of this change are several-fold:

- Facilitates radial build definitions that begin at toroidal and poloidal angles other than 0 degrees
- Builds can span any toroidal extent – no longer need to repeat periods
- The spline surface fitting routine tends to be more robust against steep gradients in IVC thickness matrices
- IVC outer surfaces tend to be smoother
- IVC file sizes are reduced

### List of changes in branch:

- Modifies ParaStell’s `Surface.generate_surface` method to use CadQuery’s `Face.makeSplineApprox` surface spline technique instead of its `Solid.makeLoft` routine
- Modifies ParaStell’s `InVesselBuild.generate_components` method to construct CAD solids by assembling necessary surfaces, instead of performing a cut operation
- Adds `InVesselBuild._check_edge` method
- Removes the now extraneous `Rib` class and moves any necessary methods to the `Surface` class
- Renames `num_ribs` and `num_rib_pts` parameters due to removal of `Rib` class
- Removes the now extraneous `repeat` parameter
- Introduces new parameter `transpose_fit`, which is a flag to indicate that the 2-D iterable of points through which each spline surface is fit should be transposed. This swaps the order in which the grid axes are iterated over. For a yet-to-be-understood reason, this can fix errant CAD generation.
- Adds `min_mesh_size` and `max_mesh_size` arguments to the `InVesselBuild.export_cad_to_dagmc` method
- Modifies the `utils.normalize` function to allow 3-D NumPy arrays
- Updates documentation

### Issues to be solved:

- While CAD generation more robust than lofting workflow, still temperamental to some degree
- In-vessel build test failing for unusual reason

Closes #26
Closes #170

### Illustration of new CAD generation workflow:

<img width="400" alt="Screenshot 2024-10-25 at 11 53 47 AM" src="https://github.com/user-attachments/assets/725aa7ab-bd78-453c-a22c-dc142baac9c8">

Figure 1. Create separate surfaces for outer surface and end caps (plasma/chamber).

<img width="400" alt="Screenshot 2024-10-25 at 11 54 01 AM" src="https://github.com/user-attachments/assets/c43e5aa3-5abe-434e-b65e-04e4690ca52f">

Figure 2. Combine surfaces into single solid (plasma/chamber).

<img width="400" alt="Screenshot 2024-10-25 at 11 54 32 AM" src="https://github.com/user-attachments/assets/f5240129-5f97-4652-9a8f-4a5ea8798098">

Figure 3. Create separate surfaces for inner surface (outer surface of interior component), outer surface, and end caps.

<img width="400" alt="Screenshot 2024-10-25 at 11 54 46 AM" src="https://github.com/user-attachments/assets/92a5e4f8-c09c-498f-ab8a-a32c81d244b7">

Figure 4. Combine surfaces into single solid.

### Demonstration of new capabilities:

<img width="400" alt="Screenshot 2024-10-25 at 12 34 27 PM" src="https://github.com/user-attachments/assets/0c91d0d3-14e1-4a9c-ab5a-cc23f0320c82">

Figure 5. 360-degree geometry.

<img width="400" alt="Screenshot 2024-10-25 at 12 40 15 PM" src="https://github.com/user-attachments/assets/8cc2bc20-5149-47ee-b5b0-8d8a01f8d0fb">

Figure 6. 360-degree geometry (cut at mid-plane, visualized in ParaView).

<img width="400" alt="Screenshot 2024-10-25 at 11 42 07 AM" src="https://github.com/user-attachments/assets/f09b7d3d-a13e-4154-84a9-7ff0fa73adf3">

Figure 7. In-vessel build with thickness matrix of component defined as `200 * numpy.random.rand(9, 9)`.
