### PR TITLE
Implement alternating division schemes between adjacent hexahedra and wedges

### DIFF
--- a/parastell/source_mesh.py
+++ b/parastell/source_mesh.py
@@ -388,19 +388,19 @@ class SourceMesh(object):
         # avoid gaps and overlaps between non-planar hexahedron faces
         if alternate_scheme:
             hex_canon_ids = [
-                [idx_list[0], idx_list[2], idx_list[1], idx_list[5]],
-                [idx_list[0], idx_list[3], idx_list[2], idx_list[7]],
-                [idx_list[0], idx_list[7], idx_list[5], idx_list[4]],
-                [idx_list[7], idx_list[2], idx_list[5], idx_list[6]],
-                [idx_list[0], idx_list[2], idx_list[5], idx_list[7]],
-            ]
-        else:
-            hex_canon_ids = [
                 [idx_list[0], idx_list[3], idx_list[1], idx_list[4]],
                 [idx_list[1], idx_list[3], idx_list[2], idx_list[6]],
                 [idx_list[1], idx_list[4], idx_list[6], idx_list[5]],
                 [idx_list[3], idx_list[6], idx_list[4], idx_list[7]],
                 [idx_list[1], idx_list[3], idx_list[6], idx_list[4]],
+            ]
+        else:
+            hex_canon_ids = [
+                [idx_list[0], idx_list[2], idx_list[1], idx_list[5]],
+                [idx_list[0], idx_list[3], idx_list[2], idx_list[7]],
+                [idx_list[0], idx_list[7], idx_list[5], idx_list[4]],
+                [idx_list[7], idx_list[2], idx_list[5], idx_list[6]],
+                [idx_list[0], idx_list[2], idx_list[5], idx_list[7]],
             ]
 
         for vertex_ids in hex_canon_ids:

--- a/parastell/source_mesh.py
+++ b/parastell/source_mesh.py
@@ -139,7 +139,7 @@ class SourceMesh(object):
 
     @num_theta.setter
     def num_theta(self, value):
-        if value % 2 != 1.0:
+        if value % 2 != 1:
             e = AttributeError(
                 "To ensure that tetrahedral faces are coincident at the end of "
                 "the closed poloidal loop, the number of poloidal intervals "
@@ -169,7 +169,7 @@ class SourceMesh(object):
             self._logger.error(e.args[0])
             raise e
 
-        if angle == 360.0 and self._num_phi % 2 != 1.0:
+        if angle == 360.0 and self._num_phi % 2 != 1:
             e = AttributeError(
                 "To ensure that tetrahedral faces are coincident at the end of "
                 "the closed toroidal loop, the number of toroidal intervals "

--- a/parastell/source_mesh.py
+++ b/parastell/source_mesh.py
@@ -165,12 +165,14 @@ class SourceMesh(object):
 
     @toroidal_extent.setter
     def toroidal_extent(self, angle):
-        if angle > 360.0:
+        angle = np.deg2rad(angle)
+
+        if angle > 2 * np.pi:
             e = AttributeError("Toroidal extent cannot exceed 360.0 degrees.")
             self._logger.error(e.args[0])
             raise e
 
-        if angle == 360.0 and self._num_toroidal_pts % 2 != 1:
+        if angle == 2 * np.pi and self._num_toroidal_pts % 2 != 1:
             e = AttributeError(
                 "To ensure that tetrahedral faces are coincident at the end of "
                 "the closed toroidal loop, the number of toroidal intervals "
@@ -180,7 +182,7 @@ class SourceMesh(object):
             self._logger.error(e.args[0])
             raise e
 
-        self._toroidal_extent = np.deg2rad(angle)
+        self._toroidal_extent = angle
 
     @property
     def logger(self):

--- a/parastell/source_mesh.py
+++ b/parastell/source_mesh.py
@@ -475,25 +475,37 @@ class SourceMesh(object):
         self.mesh_set = self.mbc.create_meshset()
         self.mbc.add_entity(self.mesh_set, self.verts)
 
+        # Initialize alternate scheme flag for adjacent toroidal blocks
+        toroidal_alt_scheme = False
+
         for phi_idx in range(self.num_phi - 1):
             # Initialize alternate scheme flag at beginning of each toroidal
             # block
-            alternate_scheme = False
+            alternate_scheme = toroidal_alt_scheme
+
             # Create tetrahedra for wedges at center of plasma
             for theta_idx in range(1, self.num_theta):
                 alternate_scheme = self._create_tets_from_wedge(
                     theta_idx, phi_idx, alternate_scheme
                 )
 
+            # Initialize alternate scheme flag for adjacent CFS blocks
+            cfs_alt_scheme = not toroidal_alt_scheme
+
             # Create tetrahedra for hexahedra beyond center of plasma
             for s_idx in range(self.num_s - 2):
                 # Initialize alternate scheme flag at beginning of each
                 # CFS block
-                alternate_scheme = False
+                alternate_scheme = cfs_alt_scheme
+
                 for theta_idx in range(1, self.num_theta):
                     alternate_scheme = self._create_tets_from_hex(
                         s_idx, theta_idx, phi_idx, alternate_scheme
                     )
+
+                cfs_alt_scheme = not cfs_alt_scheme
+
+            toroidal_alt_scheme = not toroidal_alt_scheme
 
     def export_mesh(self, filename="source_mesh", export_dir=""):
         """Use PyMOAB interface to write source mesh with source strengths

--- a/tests/test_parastell.py
+++ b/tests/test_parastell.py
@@ -103,7 +103,7 @@ def test_parastell(stellarator):
     assert Path(step_filename_exp).with_suffix(".step").exists()
     assert Path(mesh_filename_exp).with_suffix(".h5m").exists()
 
-    mesh_size = (4, 8, 4)
+    mesh_size = (6, 41, 9)
     toroidal_extent = 15.0
 
     stellarator.construct_source_mesh(mesh_size, toroidal_extent)

--- a/tests/test_source_mesh.py
+++ b/tests/test_source_mesh.py
@@ -34,17 +34,17 @@ def source_mesh():
 
 def test_mesh_basics(source_mesh):
 
-    num_s_exp = 6
-    num_theta_exp = 41
-    num_phi_exp = 9
+    num_cfs_exp = 6
+    num_poloidal_pts_exp = 41
+    num_toroidal_pts_exp = 9
     tor_ext_exp = 15.0
     scale_exp = 100
 
     remove_files()
 
-    assert source_mesh.num_s == num_s_exp
-    assert source_mesh.num_theta == num_theta_exp
-    assert source_mesh.num_phi == num_phi_exp
+    assert source_mesh.num_cfs_pts == num_cfs_exp
+    assert source_mesh.num_poloidal_pts == num_poloidal_pts_exp
+    assert source_mesh.num_toroidal_pts == num_toroidal_pts_exp
     assert source_mesh.toroidal_extent == np.deg2rad(tor_ext_exp)
     assert source_mesh.scale == scale_exp
 
@@ -53,18 +53,20 @@ def test_mesh_basics(source_mesh):
 
 def test_vertices(source_mesh):
 
-    num_s = 6
-    num_theta = 41
-    num_phi = 9
+    num_cfs_exp = 6
+    num_poloidal_pts_exp = 41
+    num_toroidal_pts_exp = 9
 
-    num_verts_exp = num_phi * ((num_s - 1) * (num_theta - 1) + 1)
+    num_verts_exp = num_toroidal_pts_exp * (
+        (num_cfs_exp - 1) * (num_poloidal_pts_exp - 1) + 1
+    )
 
     remove_files()
 
     source_mesh.create_vertices()
 
     assert source_mesh.coords.shape == (num_verts_exp, 3)
-    assert source_mesh.coords_s.shape == (num_verts_exp,)
+    assert source_mesh.coords_cfs.shape == (num_verts_exp,)
     assert len(source_mesh.verts) == num_verts_exp
 
     remove_files()

--- a/tests/test_source_mesh.py
+++ b/tests/test_source_mesh.py
@@ -24,8 +24,8 @@ def source_mesh():
 
     # Set mesh size to minimum that maintains element aspect ratios that do not
     # result in negative volumes
-    mesh_size = (6, 41, 51)
-    toroidal_extent = 90.0
+    mesh_size = (6, 41, 9)
+    toroidal_extent = 15.0
 
     source_mesh_obj = sm.SourceMesh(vmec_obj, mesh_size, toroidal_extent)
 
@@ -36,8 +36,8 @@ def test_mesh_basics(source_mesh):
 
     num_s_exp = 6
     num_theta_exp = 41
-    num_phi_exp = 51
-    tor_ext_exp = 90.0
+    num_phi_exp = 9
+    tor_ext_exp = 15.0
     scale_exp = 100
 
     remove_files()
@@ -55,7 +55,7 @@ def test_vertices(source_mesh):
 
     num_s = 6
     num_theta = 41
-    num_phi = 51
+    num_phi = 9
 
     num_verts_exp = num_phi * ((num_s - 1) * (num_theta - 1) + 1)
 
@@ -74,7 +74,7 @@ def test_mesh_generation(source_mesh):
 
     num_s = 6
     num_theta = 41
-    num_phi = 51
+    num_phi = 9
 
     tets_per_wedge = 3
     tets_per_hex = 5


### PR DESCRIPTION
Modifies the source mesh workflow to alternate the scheme by which hexahedra and wedges are split into tetrahedra. The alternating schemes ensure that the faces of adjacent tetrahedra, but not belonging to the same hexahedron or wedge, match one another. This avoids gaps and overlaps between adjacent non-planar hexahedron and wedge faces. This alignment is ensured for adjacent wedge-wedge, wedge-hexahedron, and hexahedron-hexahedron pairs. Code changes are as follows:

- Introduces `alternate_scheme`, `toroidal_alt_scheme`, and `cfs_alt_scheme` boolean parameters to control whether an alternate division scheme should be used for a given element
- Introduces an alternate division scheme, in the form of MOAB canonical indices defining the tetrahedral division of a given element, for both hexahedra and wedges
- Introduces checks to ensure the number of poloidal grid intervals and (conditionally) the number of toroidal grid intervals are even
- Modifies naming convention of flux-coordinate indices, lists, etc. to be more intuitive
- Modifies vertex indexing scheme to be more intuitive
- Reduces toroidal extent of mesh in `test_source_mesh` unit tests

The alternate splitting schemes are illustrated below. Plots will follow to demonstrate expected behavior of total volume and total source strength as a function of mesh discretization.

(a)<img width="250" alt="Screenshot 2024-11-01 at 2 59 13 PM" src="https://github.com/user-attachments/assets/6bc7cb20-0f6e-4c29-a365-1c0f416ce5af">
(b)<img width="250" alt="Screenshot 2024-11-01 at 3 07 21 PM" src="https://github.com/user-attachments/assets/b447327e-9bd6-4503-a408-8dc0b09447d8">

Figure 1. Alternate schemes for adjacent hexahedra. (a) Original and (b) alternate.

(a)<img width="250" alt="Screenshot 2024-11-01 at 3 24 55 PM" src="https://github.com/user-attachments/assets/0a8bff5d-858d-425a-98f1-f4de6a67a915">
(b)<img width="250" alt="Screenshot 2024-11-01 at 3 22 00 PM" src="https://github.com/user-attachments/assets/f96913d8-237e-42fb-b0e7-e9d051a329d6">

Figure 2. Alternate schemes for adjacent wedges. (a) Original and (b) alternate.

Closes #168