### PR TITLE
Create Facets From Point Cloud, and Volumes From Facets With Cubit

### DIFF
--- a/parastell/cubit_io.py
+++ b/parastell/cubit_io.py
@@ -51,6 +51,23 @@ def import_step_cubit(filename, import_dir):
     return vol_id
 
 
+def import_cub5_cubit(filename, import_dir):
+    """Imports cub5 file with Coreform Cubit with default import settings.
+    Arguments:
+        filename (str): name of cub5 input file.
+        import_dir (str): directory from which to import cub5 file.
+    Returns:
+        vol_id (int): Cubit volume ID of imported CAD solid.
+    """
+    init_cubit()
+    import_path = Path(import_dir) / Path(filename).with_suffix(".cub5")
+    cubit.cmd(
+        f'import cubit "{import_path}" nofreesurfaces attributes_on separate_bodies'
+    )
+    vol_id = cubit.get_last_id("volume")
+    return vol_id
+
+
 def export_step_cubit(filename, export_dir=""):
     """Export CAD solid as a STEP file via Coreform Cubit.
 

--- a/parastell/invessel_build.py
+++ b/parastell/invessel_build.py
@@ -307,6 +307,16 @@ class InVesselBuild(object):
                     )
                     prev_outer_surface_id = outer_surface_id
 
+    def import_geom_cubit(self):
+        if self.cubit_volumes:
+            self.import_cub5_cubit()
+        else:
+            self.import_step_cubit()
+
+    def import_cub5_cubit(self):
+        """Import cub5 files from in-vessel build into Coreform Cubit"""
+        cubit_io.import_cub5_cubit("invessel_build.cub5", self.export_dir)
+
     def import_step_cubit(self):
         """Imports STEP files from in-vessel build into Coreform Cubit."""
         for name, data in self.radial_build.radial_build.items():
@@ -329,6 +339,18 @@ class InVesselBuild(object):
                 ".step"
             )
             cq.exporters.export(component, str(export_path))
+
+    def save_cub5(self, filename="invessel_build.cub5", export_dir=""):
+        """Save current state of cubit model.
+
+        Arguments:
+            filename (str): name to save file as.
+            export_dir (str): directory in which to save the cub5 file.
+        """
+        self.export_dir = export_dir
+        cubit.cmd(
+            f'save cub5 "{Path(self.export_dir) / Path(filename).with_suffix(".cub5")}" overwrite'
+        )
 
     def export_cad_to_dagmc(self, dagmc_filename="dagmc", export_dir=""):
         """Exports DAGMC neutronics H5M file of ParaStell in-vessel components

--- a/parastell/parastell.py
+++ b/parastell/parastell.py
@@ -190,7 +190,10 @@ class Stellarator(object):
             export_dir (str): directory to which to export the output files
                 (optional, defaults to empty string).
         """
-        self.invessel_build.export_step(export_dir=export_dir)
+        if not self.invessel_build.cubit_volumes:
+            self.invessel_build.export_step(export_dir=export_dir)
+        else:
+            self.invessel_build.save_cub5(export_dir=export_dir)
 
         if export_cad_to_dagmc:
             self.invessel_build.export_cad_to_dagmc(
@@ -379,8 +382,8 @@ class Stellarator(object):
         else:
             cubit_io.init_cubit()
 
-        if self.invessel_build and not self.invessel_build.cubit_volumes:
-            self.invessel_build.import_step_cubit()
+        if self.invessel_build:
+            self.invessel_build.import_geom_cubit()
 
         if self.magnet_set:
             self.magnet_set.import_step_cubit()


### PR DESCRIPTION
Still work in progress, but this is functioning. Uses the point cloud data from surface objects to create facets. These facets are then connected into a surface, and the ends are closed off, forming a volume. Working from outside in, the overlap from volumes is removed, and then adjacent volumes are imprinted and merged. Volume ids are stored in the radial build during building so existing dagmc export functions work no problem. As can be seen from the diff here, this isn't particularly complicated, and it will be nice to have options when the splines are acting up, even if there are perhaps better ways long term to make this faceted representation.

Here's the geometry using the inputs from the parastell example, built using this workflow.
![image](https://github.com/user-attachments/assets/a7f286c0-a936-4b19-8e63-0c17f20441b5)
