### PR TITLE
Adds support for meshing in-vessel components

### DIFF
--- a/parastell/invessel_build.py
+++ b/parastell/invessel_build.py
@@ -346,6 +346,33 @@ class InVesselBuild(object):
 
         model.export_dagmc_h5m_file(filename=str(export_path))
 
+    def export_invessel_component_mesh(
+        self, components, mesh_size=5, import_dir="", export_dir=""
+    ):
+        """Creates a tetrahedral mesh of an in-vessel component volume
+        via Coreform Cubit and exports it as H5M file.
+
+        Arguments:
+            components (array of strings): array containing the name
+                of the in-vessel components to be meshed.
+            mesh_size (int): controls the size of the mesh. Takes values
+                between 1 (finer) and 10 (coarser) (optional, defaults to 5).
+            import_dir (str): directory containing the STEP file of
+                the in-vessel component (optional, defaults to empty string).
+            export_dir (str): directory to which to export the h5m
+                output file (optional, defaults to empty string).
+        """
+        for component in components:
+            vol_id = cubit_io.import_step_cubit(component, import_dir)
+            cubit.cmd(f"volume {vol_id} scheme tetmesh")
+            cubit.cmd(f"volume {vol_id} size auto factor {mesh_size}")
+            cubit.cmd(f"mesh volume {vol_id}")
+            cubit_io.export_mesh_cubit(
+                filename=component,
+                export_dir=export_dir,
+                delete_upon_export=False,
+            )
+
 
 class Surface(object):
     """An object representing a surface formed by lofting across a set of

--- a/parastell/parastell.py
+++ b/parastell/parastell.py
@@ -191,6 +191,27 @@ class Stellarator(object):
                 dagmc_filename=dagmc_filename, export_dir=export_dir
             )
 
+    def export_invessel_component_mesh(
+        self, components, mesh_size=5, import_dir="", export_dir=""
+    ):
+        """Creates a tetrahedral mesh of an in-vessel component volume
+        via Coreform Cubit and exports it as H5M file.
+
+        Arguments:
+            components (array of strings): array containing the name
+                of the in-vessel components to be meshed.
+            mesh_size (int): controls the size of the mesh. Takes values
+                between 1 (finer) and 10 (coarser) (optional, defaults to 5).
+            import_dir (str): directory containing the STEP file of
+                the in-vessel component (optional, defaults to empty string).
+            export_dir (str): directory to which to export the h5m
+                output file (optional, defaults to empty string).
+        """
+        self._logger.info("Exporting in-vessel components mesh...")
+        self.invessel_build.export_invessel_component_mesh(
+            components, mesh_size, import_dir, export_dir
+        )
+
     def construct_magnets(
         self, coils_file, width, thickness, toroidal_extent, **kwargs
     ):

--- a/tests/test_invessel_build.py
+++ b/tests/test_invessel_build.py
@@ -124,9 +124,12 @@ def test_ivb_exports(invessel_build):
     invessel_build.generate_components()
     invessel_build.export_step()
     invessel_build.export_cad_to_dagmc()
+    invessel_build.export_invessel_component_mesh()
 
     assert Path("chamber.step").exists()
     assert Path("component.step").exists()
     assert Path("dagmc.h5m").exists()
+    assert Path("chamber.h5m").exists()
+    assert Path("component.h5m").exists()
 
     remove_files()


### PR DESCRIPTION
This pull request introduces a method for generating a tetrahedral mesh of individual in-vessel components and exporting the mesh in .h5m format. The process involves the following steps:

1. Importing the STEP file: The method imports the STEP file corresponding to the component.
2. Mesh Generation: Using Cubit, a tetrahedral mesh is created for the imported component.
3. Exporting Mesh: The resulting meshed volume is exported in .exo format, which is then converted to .h5m using MOAB.

When using the method, the names of the in-vessel components must match the names specified in the radial build dictionary. Also, the mesh size can be customized using the mesh_size argument. More information on mesh sizing functions can be found [here](https://coreform.com/cubit_help/mesh_generation/interval_assignment/automatic_specification.htm).