### PR TITLE
Update Cubit Version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Populate environment and run tests
         run: |
           . /opt/etc/bashrc
-          sed -e "s/@SERVER@/${rlmSERVER}/" -e "s/@PASSWORD@/${rlmPASSWD}/" /opt/Coreform-Cubit-2023.11/bin/licenses/rlmcloud.in > /opt/Coreform-Cubit-2023.11/bin/licenses/rlmcloud.lic
+          sed -e "s/@SERVER@/${rlmSERVER}/" -e "s/@PASSWORD@/${rlmPASSWD}/" /opt/Coreform-Cubit-2024.8/bin/licenses/rlmcloud.in > /opt/Coreform-Cubit-2024.8/bin/licenses/rlmcloud.lic
           export PYTHONPATH=${PYTHONPATH}:`pwd`
           cd tests
           pytest -v .

--- a/.github/workflows/docker_publish.yml
+++ b/.github/workflows/docker_publish.yml
@@ -69,7 +69,7 @@ jobs:
       - name: Populate environment and run tests
         run: |
           . /opt/etc/bashrc
-          sed -e "s/@SERVER@/${rlmSERVER}/" -e "s/@PASSWORD@/${rlmPASSWD}/" /opt/Coreform-Cubit-2023.11/bin/licenses/rlmcloud.in > /opt/Coreform-Cubit-2023.11/bin/licenses/rlmcloud.lic
+          sed -e "s/@SERVER@/${rlmSERVER}/" -e "s/@PASSWORD@/${rlmPASSWD}/" /opt/Coreform-Cubit-2024.8/bin/licenses/rlmcloud.in > /opt/Coreform-Cubit-2024.8/bin/licenses/rlmcloud.lic
           export PYTHONPATH=${PYTHONPATH}:`pwd`
           cd tests
           pytest -v .

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,12 +31,12 @@ RUN apt-get install -y libgl1-mesa-glx \
                         libxinerama1
 
 # Download Coreform Cubit
-RUN wget -O /cubit.deb https://f002.backblazeb2.com/file/cubit-downloads/Coreform-Cubit/Releases/Linux/Coreform-Cubit-2023.11%2B43088-Lin64.deb
+RUN wget -O /cubit.deb https://f002.backblazeb2.com/file/cubit-downloads/Coreform-Cubit/Releases/Linux/Coreform-Cubit-2024.8%2B52155-Lin64.deb
 
 # Install Cubit
 RUN dpkg -i cubit.deb
-ENV PYTHONPATH=/opt/Coreform-Cubit-2023.11/bin/
-COPY ./rlmcloud.in /opt/Coreform-Cubit-2023.11/bin/licenses/rlmcloud.in
+ENV PYTHONPATH=/opt/Coreform-Cubit-2024.8/bin/
+COPY ./rlmcloud.in /opt/Coreform-Cubit-2024.8/bin/licenses/rlmcloud.in
 
 RUN mkdir -p /opt/etc
 RUN cp /root/.bashrc /opt/etc/bashrc

--- a/Examples/config.yaml
+++ b/Examples/config.yaml
@@ -83,7 +83,6 @@ source_mesh:
 
 dagmc_export:
   skip_imprint: False
-  legacy_faceting: True
   filename: dagmc
 
 cub5_export: False

--- a/Examples/nwl_geom_example.py
+++ b/Examples/nwl_geom_example.py
@@ -1,6 +1,6 @@
 from pathlib import Path
 import parastell.parastell as ps
-from parastell.cubit_io import tag_surface_native
+from parastell.cubit_io import tag_surface
 
 # Define directory to export all output files to
 export_dir = ""
@@ -46,6 +46,6 @@ for tet in strengths:
     file.write(f"{tet}\n")
 
 # Export DAGMC neutronics H5M file
-stellarator.build_cubit_model(skip_imprint=True, legacy_faceting=False)
-tag_surface_native(1, "vacuum")
+stellarator.build_cubit_model(skip_imprint=True)
+tag_surface(1, "vacuum")
 stellarator.export_dagmc(filename="nwl_geom", export_dir=export_dir)

--- a/Examples/parastell_example.py
+++ b/Examples/parastell_example.py
@@ -78,7 +78,7 @@ stellarator.construct_source_mesh(mesh_size, toroidal_extent)
 stellarator.export_source_mesh(filename="source_mesh", export_dir=export_dir)
 
 # Build Cubit model of Parastell Components
-stellarator.build_cubit_model(skip_imprint=False, legacy_faceting=True)
+stellarator.build_cubit_model(skip_imprint=False)
 
 # Export DAGMC neutronics H5M file
 stellarator.export_dagmc(filename="dagmc", export_dir=export_dir)

--- a/Examples/radial_distance_example.py
+++ b/Examples/radial_distance_example.py
@@ -108,7 +108,7 @@ stellarator.construct_source_mesh(mesh_size, toroidal_extent)
 stellarator.export_source_mesh(filename="source_mesh", export_dir=export_dir)
 
 # Build Cubit model of Parastell Components
-stellarator.build_cubit_model(skip_imprint=False, legacy_faceting=True)
+stellarator.build_cubit_model(skip_imprint=False)
 
 # Export DAGMC neutronics H5M file
 stellarator.export_dagmc(filename="dagmc", export_dir=export_dir)

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ ParaStell depends on:
 - [CadQuery](https://cadquery.readthedocs.io/en/latest/installation.html)
 - [PyStell](https://github.com/aaroncbader/pystell_uw)
 - [MOAB](https://bitbucket.org/fathomteam/moab/src/master/)
-- [Coreform Cubit](https://coreform.com/products/downloads/), version 2023.11
+- [Coreform Cubit](https://coreform.com/products/downloads/)
 - [CAD-to-DAGMC](https://github.com/fusion-energy/cad_to_dagmc)
 - [OpenMC](https://github.com/openmc-dev/openmc)
 - [NumPy](https://numpy.org/install/)
@@ -45,10 +45,10 @@ conda activate parastell_env
 Alternatively, view `INSTALL.md` for instructions on manually installing these Python dependencies using mamba.
 
 ### Install Coreform Cubit
-Download and install version 2023.11 from [Coreform's Website](https://coreform.com/products/downloads/), then add the `/Coreform-Cubit-2023.11/bin/` directory to your `PYTHONPATH` by adding a line similar to the following to your `.bashrc` file:
+Download and install the latest version from [Coreform's Website](https://coreform.com/products/downloads/), then add the `/Coreform-Cubit-[version]/bin/` directory to your `PYTHONPATH` by adding a line similar to the following to your `.bashrc` file:
 
 ```bash
-export PYTHONPATH=$PYTHONPATH:$HOME/Coreform-Cubit-2023.11/bin/
+export PYTHONPATH=$PYTHONPATH:$HOME/Coreform-Cubit-[version]/bin/
 ```
 
 Replace `$HOME` with the path to the Coreform Cubit directory on your system. Additional information about adding modules to your `PYTHONPATH` can be found [here](https://www.tutorialspoint.com/How-to-set-python-environment-variable-PYTHONPATH-on-Linux).

--- a/parastell/cubit_io.py
+++ b/parastell/cubit_io.py
@@ -13,9 +13,6 @@ def init_cubit():
     global initialized
 
     if not initialized:
-        cubit_plugin_dir = Path(
-            os.path.dirname(inspect.getfile(cubit))
-        ) / Path("plugins")
         cubit.init(
             [
                 "cubit",
@@ -25,8 +22,6 @@ def init_cubit():
                 "off",
                 "-warning",
                 "off",
-                "-commandplugindir",
-                str(cubit_plugin_dir),
             ]
         )
         initialized = True

--- a/parastell/cubit_io.py
+++ b/parastell/cubit_io.py
@@ -111,7 +111,7 @@ def export_mesh_cubit(filename, export_dir="", delete_upon_export=True):
 
 def tag_surface(surface_id, tag):
     """Applies a boundary condition to a surface in cubit following the
-        native coreform syntax
+    Coreform syntax.
 
     Arguments:
         surface_id (int): Surface to tag
@@ -129,8 +129,8 @@ def export_dagmc_cubit(
     export_dir="",
     delete_upon_export=True,
 ):
-    """Exports DAGMC neutronics H5M file of ParaStell components via native
-    faceting method for Coreform Cubit.
+    """Exports DAGMC neutronics H5M file of ParaStell components via Coreform
+    Cubit.
 
     Arguments:
         anisotropic_ratio (float): controls edge length ratio of elements

--- a/parastell/cubit_io.py
+++ b/parastell/cubit_io.py
@@ -1,6 +1,4 @@
 from pathlib import Path
-import os
-import inspect
 import subprocess
 
 import cubit
@@ -111,55 +109,7 @@ def export_mesh_cubit(filename, export_dir="", delete_upon_export=True):
         cubit.cmd(f"delete mesh volume all propagate")
 
 
-def export_dagmc_cubit_legacy(
-    faceting_tolerance=None,
-    length_tolerance=None,
-    normal_tolerance=None,
-    filename="dagmc",
-    export_dir="",
-):
-    """Exports DAGMC neutronics H5M file of ParaStell components via legacy
-    plug-in faceting method for Coreform Cubit.
-
-    Arguments:
-        faceting_tolerance (float): maximum distance a facet may be from
-            surface of CAD representation for DAGMC export (defaults to None).
-        length_tolerance (float): maximum length of facet edge for DAGMC export
-            (defaults to None).
-        normal_tolerance (float): maximum change in angle between normal vector
-            of adjacent facets (defaults to None).
-        filename (str): name of DAGMC output file, excluding '.h5m' extension
-            (defaults to 'dagmc').
-        export_dir (str): directory to which to export the DAGMC output file
-            (defaults to empty string).
-    """
-    init_cubit()
-
-    tol_str = ""
-
-    if faceting_tolerance is not None:
-        tol_str += f"faceting_tolerance {faceting_tolerance}"
-    if length_tolerance is not None:
-        tol_str += f"length_tolerance {length_tolerance}"
-    if normal_tolerance is not None:
-        tol_str += f"normal_tolerance {normal_tolerance}"
-
-    export_path = Path(export_dir) / Path(filename).with_suffix(".h5m")
-    cubit.cmd(f'export dagmc "{export_path}" {tol_str} make_watertight')
-
-
-def tag_surface_legacy(surface_id, tag):
-    """Applies a boundary condition to a surface in cubit following UWUW
-    syntax.
-
-    Arguments:
-        surface_id (int): Surface to tag
-        tag (str): boundary type
-    """
-    cubit.cmd(f'group "boundary:{tag}" add surf {surface_id}')
-
-
-def tag_surface_native(surface_id, tag):
+def tag_surface(surface_id, tag):
     """Applies a boundary condition to a surface in cubit following the
         native coreform syntax
 
@@ -172,7 +122,7 @@ def tag_surface_native(surface_id, tag):
     cubit.cmd(f"sideset {surface_id} add surface {surface_id}")
 
 
-def export_dagmc_cubit_native(
+def export_dagmc_cubit(
     anisotropic_ratio=100.0,
     deviation_angle=5.0,
     filename="dagmc",

--- a/parastell/cubit_io.py
+++ b/parastell/cubit_io.py
@@ -205,7 +205,7 @@ def export_dagmc_cubit_native(
     cubit.cmd("mesh surface all")
 
     export_path = Path(export_dir) / Path(filename).with_suffix(".h5m")
-    cubit.cmd(f'export cf_dagmc "{export_path}" overwrite')
+    cubit.cmd(f'export dagmc "{export_path}" overwrite')
 
     # Delete any meshes present to prevent inclusion in future Cubit mesh
     # exports

--- a/parastell/parastell.py
+++ b/parastell/parastell.py
@@ -333,26 +333,7 @@ class Stellarator(object):
         """
         self.source_mesh.export_mesh(filename=filename, export_dir=export_dir)
 
-    def _tag_materials_legacy(self):
-        """Applies material tags to corresponding CAD volumes for legacy DAGMC
-        neutronics model export.
-        (Internal function not intended to be called externally)
-        """
-        if self.magnet_set:
-            vol_id_str = " ".join(
-                str(i) for i in list(self.magnet_set.volume_ids)
-            )
-            cubit.cmd(
-                f'group "mat:{self.magnet_set.mat_tag}" add volume {vol_id_str}'
-            )
-
-        if self.invessel_build:
-            for data in self.invessel_build.radial_build.radial_build.values():
-                cubit.cmd(
-                    f'group "mat:{data["mat_tag"]}" add volume {data["vol_id"]}'
-                )
-
-    def _tag_materials_native(self):
+    def _tag_materials(self):
         """Applies material tags to corresponding CAD volumes for native DAGMC
         neutronics model export.
         (Internal function not intended to be called externally)
@@ -371,7 +352,7 @@ class Stellarator(object):
                 vol_id_str = str(block_id)
                 make_material_block(data["mat_tag"], block_id, vol_id_str)
 
-    def build_cubit_model(self, skip_imprint=False, legacy_faceting=True):
+    def build_cubit_model(self, skip_imprint=False):
         """Build model for DAGMC neutronics H5M file of Parastell components via
         Coreform Cubit
 
@@ -379,11 +360,7 @@ class Stellarator(object):
             skip_imprint (bool): choose whether to imprint and merge all in
                 Coreform Cubit or to merge surfaces based on import order and
                 geometry information (optional, defaults to False).
-            legacy_faceting (bool): choose legacy or native faceting for DAGMC
-                export (optional, defaults to True).
         """
-        self.legacy_faceting = legacy_faceting
-
         self._logger.info(
             "Building DAGMC neutronics model via Coreform Cubit..."
         )
@@ -406,10 +383,7 @@ class Stellarator(object):
             cubit.cmd("imprint volume all")
             cubit.cmd("merge volume all")
 
-        if legacy_faceting:
-            self._tag_materials_legacy()
-        else:
-            self._tag_materials_native()
+        self._tag_materials()
 
     def export_dagmc(self, filename="dagmc", export_dir="", **kwargs):
         """Exports DAGMC neutronics H5M file of ParaStell components via
@@ -444,14 +418,9 @@ class Stellarator(object):
 
         self._logger.info("Exporting DAGMC neutronics model...")
 
-        if self.legacy_faceting:
-            cubit_io.export_dagmc_cubit_legacy(
-                filename=filename, export_dir=export_dir, **kwargs
-            )
-        else:
-            cubit_io.export_dagmc_cubit_native(
-                filename=filename, export_dir=export_dir, **kwargs
-            )
+        cubit_io.export_dagmc_cubit(
+            filename=filename, export_dir=export_dir, **kwargs
+        )
 
     def export_cub5(self, filename="stellarator", export_dir=""):
         """Export native Coreform Cubit format (cub5) of Parastell model.

--- a/parastell/parastell.py
+++ b/parastell/parastell.py
@@ -13,7 +13,7 @@ from . import source_mesh as sm
 from . import cubit_io
 from .utils import read_yaml_config, filter_kwargs, m2cm
 
-build_cubit_model_allowed_kwargs = ["skip_imprint", "legacy_faceting"]
+build_cubit_model_allowed_kwargs = ["skip_imprint"]
 export_dagmc_allowed_kwargs = [
     "faceting_tolerance",
     "length_tolerance",
@@ -669,7 +669,7 @@ def parastell():
         nwl_required_keys = ["toroidal_angles", "poloidal_angles", "wall_s"]
 
         nwl_build = {}
-        for key in nwl_keys:
+        for key in nwl_required_keys:
             nwl_build[key] = invessel_build[key]
         nwl_build["radial_build"] = {}
 

--- a/parastell/parastell.py
+++ b/parastell/parastell.py
@@ -14,18 +14,11 @@ from . import cubit_io
 from .utils import read_yaml_config, filter_kwargs, m2cm
 
 build_cubit_model_allowed_kwargs = ["skip_imprint"]
-export_dagmc_allowed_kwargs = [
-    "faceting_tolerance",
-    "length_tolerance",
-    "normal_tolerance",
-    "anisotropic_ratio",
-    "deviation_angle",
-]
+export_dagmc_allowed_kwargs = ["anisotropic_ratio", "deviation_angle"]
 
 
 def make_material_block(mat_tag, block_id, vol_id_str):
-    """Issue commands to make a material block using Cubit's
-    native capabilities.
+    """Issue commands to make a material block in Cubit.
 
     Arguments:
        mat_tag (str) : name of material block
@@ -334,8 +327,8 @@ class Stellarator(object):
         self.source_mesh.export_mesh(filename=filename, export_dir=export_dir)
 
     def _tag_materials(self):
-        """Applies material tags to corresponding CAD volumes for native DAGMC
-        neutronics model export.
+        """Applies material tags to corresponding CAD volumes for DAGMC
+        neutronics model export via Coreform Cubit.
         (Internal function not intended to be called externally)
         """
         cubit.cmd("set duplicate block elements off")
@@ -396,23 +389,11 @@ class Stellarator(object):
                 (optional, defaults to empty string).
 
         Optional arguments:
-            faceting_tolerance (float): maximum distance a facet may be from
-                surface of CAD representation for DAGMC export (defaults to
-                None). This attribute is used only for the legacy faceting
-                method.
-            length_tolerance (float): maximum length of facet edge for DAGMC
-                export (defaults to None). This attribute is used only for the
-                legacy faceting method.
-            normal_tolerance (float): maximum change in angle between normal
-                vector of adjacent facets (defaults to None). This attribute is
-                used only for the legacy faceting method.
             anisotropic_ratio (float): controls edge length ratio of elements
-                (defaults to 100.0). This attribute is used only for the native
-                faceting method.
+                (defaults to 100.0).
             deviation_angle (float): controls deviation angle of facet from
                 surface (i.e., lesser deviation angle results in more elements
-                in areas with higher curvature) (defaults to 5.0). This
-                attribute is used only for the native faceting method.
+                in areas with higher curvature) (defaults to 5.0).
         """
         cubit_io.init_cubit()
 


### PR DESCRIPTION
Updates syntax and documentation to integrate the latest version of Cubit (version 2024.8). In addition, removes all legacy DAGMC functionality in Cubit as it is no longer supported in more recent versions.