### PR TITLE
add pydagmc to environment

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -20,3 +20,4 @@ dependencies:
       - pyyaml
       - pytest
       - git+https://github.com/aaroncbader/pystell_uw.git
+      - git+https://github.com/svalinn/pydagmc.git


### PR DESCRIPTION
Adds PyDAGMC to the testing environment. #190 depends on PyDAGMC.