### PR TITLE
Update CAD-to-DAGMC version in Conda environment file

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -9,7 +9,7 @@ dependencies:
   - scikit-learn
   - cadquery
   - moab=5.5.1[build=nompi_tempest_*]
-  - cad_to_dagmc >=0.7.5
+  - cad_to_dagmc >=0.8.2
   - ca-certificates
   - certifi
   - openssl


### PR DESCRIPTION
Updates the CAD-to-DAGMC version specified in the Conda environment file to be newer than or equal to 0.8.2 in order to incorporate API changes.