### PR TITLE
Support Custom FW Definitions

### DIFF
--- a/Examples/custom_geometry_example.py
+++ b/Examples/custom_geometry_example.py
@@ -1,0 +1,36 @@
+import parastell.invessel_build as ivb
+from parastell.utils import ribs_from_kisslinger_format, KisslingerSurface
+import numpy as np
+
+(
+    toroidal_angles,
+    num_toroidal_angles,
+    num_poloidal_angles,
+    periods,
+    custom_ribs,
+) = ribs_from_kisslinger_format("wistd_1m_alpha10.txt", scale=1)
+ks = KisslingerSurface(custom_ribs, toroidal_angles)
+ks.build_analytic_surface()
+
+toroidal_angles = np.linspace(0, 90, 64)
+poloidal_angles = np.linspace(0, 360, 64)
+
+uniform_unit_thickness = np.ones((len(toroidal_angles), len(poloidal_angles)))
+
+radial_build = ivb.RadialBuild(
+    toroidal_angles,
+    poloidal_angles,
+    1,
+    {
+        "first_wall": {"thickness_matrix": uniform_unit_thickness * 50},
+    },
+)
+invessel_build = ivb.InVesselBuild(
+    ks, radial_build, num_ribs=64, num_rib_pts=64
+)
+invessel_build.use_pydagmc = True
+invessel_build.populate_surfaces()
+invessel_build.calculate_loci()
+invessel_build.generate_components()
+invessel_build.dag_model.write_file("ivb.h5m")
+invessel_build.dag_model.write_file("ivb.vtk")

--- a/parastell/invessel_build.py
+++ b/parastell/invessel_build.py
@@ -684,6 +684,8 @@ class Rib(object):
         if not np.all(self.offset_list == 0):
             self.rib_loci += self.offset_list[:, np.newaxis] * self._normals()
 
+        self.rib_loci[-1] = self.rib_loci[0]
+
     def _generate_pymoab_verts(self, mbc):
         """Converts point-loci to MBVERTEX and adds them to a PyMOAB
         Core instance. The first and last rib loci are identical. To avoid

--- a/parastell/utils.py
+++ b/parastell/utils.py
@@ -314,7 +314,22 @@ def combine_dagmc_models(models_to_merge):
     return dagmc.DAGModel(renumberizer.mb)
 
 
-def ribs_from_kisslinger_format(filename, start_line=3, scale=m2cm):
+def rotate_ribs(ribs, angle):
+    """Rotate a set of NxMx3 set of loci about the Z axis in the
+    counter-clockwise direction"""
+    angle = np.deg2rad(angle)
+    rotation_mat = np.array(
+        [
+            [np.cos(angle), -np.sin(angle), 0],
+            [np.sin(angle), np.cos(angle), 0],
+            [0, 0, 1],
+        ]
+    )
+    ribs = np.dot(ribs, rotation_mat.T)
+    return ribs
+
+
+def ribs_from_kisslinger_format(filename, start_line=2, scale=m2cm):
     """Reads a Kisslinger format file and returns a list of toroidal angles,
     along with a list of lists of the rib loci (in x,y,z) at each toroidal
     angle. It is expected that toroidal angles are provided in degrees.
@@ -322,8 +337,7 @@ def ribs_from_kisslinger_format(filename, start_line=3, scale=m2cm):
     Arguments:
         filename (str): Path to the file to be read.
         start_line (int): Line at which the data should start being read,
-            should skip any comments and the line describing the number of
-            toroidal angles, poloidal angles, and periods. Defaults to 3.
+            should skip any comments. Defaults to 2.
         scale (float): Amount to scale the r-z coordinates by. Defaults to 100.
     Returns:
         toroidal_angles (list of float): List of all the toroidal angles in the
@@ -342,7 +356,11 @@ def ribs_from_kisslinger_format(filename, start_line=3, scale=m2cm):
     toroidal_angles = []
 
     for line in data[start_line - 1 :]:
-        if "\t" not in line:
+        if line.count("\t") == 2:
+            num_toroidal_angles, num_poloidal_angles, periods = (
+                line.rstrip().split("\t")
+            )
+        elif "\t" not in line and "#" not in line:
             toroidal_angle = float(line.rstrip())
             toroidal_angles.append(toroidal_angle)
             if len(profile) != 0:
@@ -357,33 +375,102 @@ def ribs_from_kisslinger_format(filename, start_line=3, scale=m2cm):
             profile.append([x_coord, y_coord, z_coord])
     profiles.append(profile)
 
-    return toroidal_angles, np.array(profiles)
+    return (
+        np.array(toroidal_angles),
+        num_toroidal_angles,
+        num_poloidal_angles,
+        periods,
+        np.array(profiles),
+    )
+
+
+def extract_rib_data(
+    ribs, toroidal_angles, poloidal_angles, x_data, y_data, z_data, grid_points
+):
+    for phi, rib in zip(toroidal_angles, ribs):
+        for theta, rib_locus in zip(poloidal_angles, rib):
+            x_data.append(rib_locus[0])
+            y_data.append(rib_locus[1])
+            z_data.append(rib_locus[2])
+            grid_points.append([phi, theta])
+    return x_data, y_data, z_data, grid_points
 
 
 class KisslingerSurface(object):
-    def __init__(self, rib_data):
+    def __init__(self, rib_data, toroidal_angles):
         self.rib_data = rib_data
-        self.toroidal_angles = np.linspace(0, 90, rib_data.shape[0])
+        self.toroidal_angles = toroidal_angles
+        self.num_periods = 360 / toroidal_angles[-1]
         self.poloidal_angles = np.linspace(0, 360, rib_data.shape[1])
 
-    def build_analytic_surface(self):
+    def build_analytic_surface(self, neighbors=100):
+        """Build RBF interpolators for x,y,z coordinates assuming that the
+        provided coordinates are spaced evenly in the poloidal direction"""
         x_data = []
         y_data = []
         z_data = []
         grid_points = []
-        for phi, rib in zip(self.toroidal_angles, self.rib_data):
-            for theta, rib_locus in zip(self.poloidal_angles, rib):
-                x_data.append(rib_locus[0])
-                y_data.append(rib_locus[1])
-                z_data.append(rib_locus[2])
-                grid_points.append([phi, theta])
-        self.rbf_x = RBFInterpolator(grid_points, x_data, kernel="linear")
-        self.rbf_y = RBFInterpolator(grid_points, y_data, kernel="linear")
-        self.rbf_z = RBFInterpolator(grid_points, z_data, kernel="linear")
 
-    def get_loci(self, toroidal_angles, poloidal_angles):
+        # add mock region before region to be modeled so the interpolator
+        # knows about the periodicity
+        rotated_ribs = rotate_ribs(self.rib_data, -max(self.toroidal_angles))[
+            0:-1
+        ]
+        shifted_toroidal_angles = self.toroidal_angles[0:-1] - max(
+            self.toroidal_angles
+        )
+        x_data, y_data, z_data, grid_points = extract_rib_data(
+            rotated_ribs,
+            shifted_toroidal_angles,
+            self.poloidal_angles,
+            x_data,
+            y_data,
+            z_data,
+            grid_points,
+        )
+
+        # add data for the region to be modeled
+        x_data, y_data, z_data, grid_points = extract_rib_data(
+            self.rib_data,
+            self.toroidal_angles,
+            self.poloidal_angles,
+            x_data,
+            y_data,
+            z_data,
+            grid_points,
+        )
+
+        # add mock region after region to be modeled
+        rotated_ribs = rotate_ribs(self.rib_data, max(self.toroidal_angles))[
+            1:
+        ]
+        shifted_toroidal_angles = self.toroidal_angles[1:] + max(
+            self.toroidal_angles
+        )
+
+        x_data, y_data, z_data, grid_points = extract_rib_data(
+            rotated_ribs,
+            shifted_toroidal_angles,
+            self.poloidal_angles,
+            x_data,
+            y_data,
+            z_data,
+            grid_points,
+        )
+
+        self.rbf_x = RBFInterpolator(
+            grid_points, x_data, neighbors=neighbors, kernel="linear"
+        )
+        self.rbf_y = RBFInterpolator(
+            grid_points, y_data, neighbors=neighbors, kernel="linear"
+        )
+        self.rbf_z = RBFInterpolator(
+            grid_points, z_data, neighbors=neighbors, kernel="linear"
+        )
+
+    def get_loci(self, toroidal_angles_interp, poloidal_angles_interp):
         toroidal_grid, polodial_grid = np.meshgrid(
-            toroidal_angles, poloidal_angles, indexing="ij"
+            toroidal_angles_interp, poloidal_angles_interp, indexing="ij"
         )
         grid_shape = toroidal_grid.shape
         grid_points = np.column_stack(
@@ -400,38 +487,3 @@ class KisslingerSurface(object):
         y = locus[1]
         z = locus[2]
         return x, y, z
-
-
-# class KisslingerSurface(object):
-#     def __init__(self, rib_data):
-#         self.rib_data = rib_data
-#         self.toroidal_angles = np.linspace(0, 90, rib_data.shape[0])
-#         self.poloidal_angles = np.linspace(0, 360, rib_data.shape[1])
-
-#     def build_analytic_surface(self):
-#         x_data = []
-#         y_data = []
-#         z_data = []
-#         grid_points = []
-#         for phi, rib in zip(self.toroidal_angles, self.rib_data):
-#             for theta, rib_locus in zip(self.poloidal_angles, rib):
-#                 x_data.append(rib_locus[0])
-#                 y_data.append(rib_locus[1])
-#                 z_data.append(rib_locus[2])
-#                 grid_points.append([phi, theta])
-#         self.rbf_x = RBFInterpolator(grid_points, x_data, kernel="linear")
-#         self.rbf_y = RBFInterpolator(grid_points, y_data, kernel="linear")
-#         self.rbf_z = RBFInterpolator(grid_points, z_data, kernel="linear")
-
-#     def get_loci(self, toroidal_angles, poloidal_angles):
-#         toroidal_grid, polodial_grid = np.meshgrid(
-#             toroidal_angles, poloidal_angles, indexing="ij"
-#         )
-#         grid_shape = toroidal_grid.shape
-#         grid_points = np.column_stack(
-#             (toroidal_grid.ravel(), polodial_grid.ravel())
-#         )
-#         x_points = self.rbf_x(grid_points).reshape(grid_shape)
-#         y_points = self.rbf_y(grid_points).reshape(grid_shape)
-#         z_points = self.rbf_z(grid_points).reshape(grid_shape)
-#         return np.stack((x_points, y_points, z_points), axis=-1)

--- a/parastell/utils.py
+++ b/parastell/utils.py
@@ -6,6 +6,7 @@ from functools import cached_property
 import numpy as np
 import math
 from scipy.ndimage import gaussian_filter
+from scipy.interpolate import RBFInterpolator, griddata
 from pymoab import core, types
 import dagmc
 
@@ -357,3 +358,80 @@ def ribs_from_kisslinger_format(filename, start_line=3, scale=m2cm):
     profiles.append(profile)
 
     return toroidal_angles, np.array(profiles)
+
+
+class KisslingerSurface(object):
+    def __init__(self, rib_data):
+        self.rib_data = rib_data
+        self.toroidal_angles = np.linspace(0, 90, rib_data.shape[0])
+        self.poloidal_angles = np.linspace(0, 360, rib_data.shape[1])
+
+    def build_analytic_surface(self):
+        x_data = []
+        y_data = []
+        z_data = []
+        grid_points = []
+        for phi, rib in zip(self.toroidal_angles, self.rib_data):
+            for theta, rib_locus in zip(self.poloidal_angles, rib):
+                x_data.append(rib_locus[0])
+                y_data.append(rib_locus[1])
+                z_data.append(rib_locus[2])
+                grid_points.append([phi, theta])
+        self.rbf_x = RBFInterpolator(grid_points, x_data, kernel="linear")
+        self.rbf_y = RBFInterpolator(grid_points, y_data, kernel="linear")
+        self.rbf_z = RBFInterpolator(grid_points, z_data, kernel="linear")
+
+    def get_loci(self, toroidal_angles, poloidal_angles):
+        toroidal_grid, polodial_grid = np.meshgrid(
+            toroidal_angles, poloidal_angles, indexing="ij"
+        )
+        grid_shape = toroidal_grid.shape
+        grid_points = np.column_stack(
+            (toroidal_grid.ravel(), polodial_grid.ravel())
+        )
+        x_points = self.rbf_x(grid_points).reshape(grid_shape)
+        y_points = self.rbf_y(grid_points).reshape(grid_shape)
+        z_points = self.rbf_z(grid_points).reshape(grid_shape)
+        return np.stack((x_points, y_points, z_points), axis=-1)
+
+    def vmec2xyz(self, s, theta, phi):
+        locus = self.get_loci(np.rad2deg(phi), np.rad2deg(theta))[0][0]
+        x = locus[0]
+        y = locus[1]
+        z = locus[2]
+        return x, y, z
+
+
+# class KisslingerSurface(object):
+#     def __init__(self, rib_data):
+#         self.rib_data = rib_data
+#         self.toroidal_angles = np.linspace(0, 90, rib_data.shape[0])
+#         self.poloidal_angles = np.linspace(0, 360, rib_data.shape[1])
+
+#     def build_analytic_surface(self):
+#         x_data = []
+#         y_data = []
+#         z_data = []
+#         grid_points = []
+#         for phi, rib in zip(self.toroidal_angles, self.rib_data):
+#             for theta, rib_locus in zip(self.poloidal_angles, rib):
+#                 x_data.append(rib_locus[0])
+#                 y_data.append(rib_locus[1])
+#                 z_data.append(rib_locus[2])
+#                 grid_points.append([phi, theta])
+#         self.rbf_x = RBFInterpolator(grid_points, x_data, kernel="linear")
+#         self.rbf_y = RBFInterpolator(grid_points, y_data, kernel="linear")
+#         self.rbf_z = RBFInterpolator(grid_points, z_data, kernel="linear")
+
+#     def get_loci(self, toroidal_angles, poloidal_angles):
+#         toroidal_grid, polodial_grid = np.meshgrid(
+#             toroidal_angles, poloidal_angles, indexing="ij"
+#         )
+#         grid_shape = toroidal_grid.shape
+#         grid_points = np.column_stack(
+#             (toroidal_grid.ravel(), polodial_grid.ravel())
+#         )
+#         x_points = self.rbf_x(grid_points).reshape(grid_shape)
+#         y_points = self.rbf_y(grid_points).reshape(grid_shape)
+#         z_points = self.rbf_z(grid_points).reshape(grid_shape)
+#         return np.stack((x_points, y_points, z_points), axis=-1)

--- a/parastell/utils.py
+++ b/parastell/utils.py
@@ -313,7 +313,7 @@ def combine_dagmc_models(models_to_merge):
     return dagmc.DAGModel(renumberizer.mb)
 
 
-def ribs_from_kisslinger_format(filename, start_line=3, scale=1):
+def ribs_from_kisslinger_format(filename, start_line=3, scale=m2cm):
     """Reads a Kisslinger format file and returns a list of toroidal angles,
     along with a list of lists of the rib loci (in x,y,z) at each toroidal
     angle. It is expected that toroidal angles are provided in degrees.
@@ -323,7 +323,7 @@ def ribs_from_kisslinger_format(filename, start_line=3, scale=1):
         start_line (int): Line at which the data should start being read,
             should skip any comments and the line describing the number of
             toroidal angles, poloidal angles, and periods. Defaults to 3.
-        scale (float): Amount to scale the r-z coordinates by. Defaults to 1.
+        scale (float): Amount to scale the r-z coordinates by. Defaults to 100.
     Returns:
         toroidal_angles (list of float): List of all the toroidal angles in the
             angles in the input file in degrees.

--- a/parastell/utils.py
+++ b/parastell/utils.py
@@ -311,3 +311,49 @@ def combine_dagmc_models(models_to_merge):
             renumberizer.load_file(temp_filename)
     renumberizer.renumber_ids()
     return dagmc.DAGModel(renumberizer.mb)
+
+
+def ribs_from_kisslinger_format(filename, start_line=3, scale=1):
+    """Reads a Kisslinger format file and returns a list of toroidal angles,
+    along with a list of lists of the rib loci (in x,y,z) at each toroidal
+    angle. It is expected that toroidal angles are provided in degrees.
+
+    Arguments:
+        filename (str): Path to the file to be read.
+        start_line (int): Line at which the data should start being read,
+            should skip any comments and the line describing the number of
+            toroidal angles, poloidal angles, and periods. Defaults to 3.
+        scale (float): Amount to scale the r-z coordinates by. Defaults to 1.
+    Returns:
+        toroidal_angles (list of float): List of all the toroidal angles in the
+            angles in the input file in degrees.
+        profiles (numpy array): 3 dimensional numpy array where the first
+            dimension corresponds to individual ribs, the second to the
+            position on a rib, and the third to the actual x,y,z coordinate
+            of the locus.
+    """
+
+    with open(file=filename) as file:
+        data = file.readlines()
+
+    profiles = []
+    profile = []
+    toroidal_angles = []
+
+    for line in data[start_line - 1 :]:
+        if "\t" not in line:
+            toroidal_angle = float(line.rstrip())
+            toroidal_angles.append(toroidal_angle)
+            if len(profile) != 0:
+                profiles.append(profile)
+                profile = []
+        else:
+            line = line.rstrip()
+            r_z_coords = [float(coord) * scale for coord in line.split("\t")]
+            x_coord = r_z_coords[0] * np.cos(np.deg2rad(toroidal_angle))
+            y_coord = r_z_coords[0] * np.sin(np.deg2rad(toroidal_angle))
+            z_coord = r_z_coords[1]
+            profile.append([x_coord, y_coord, z_coord])
+    profiles.append(profile)
+
+    return toroidal_angles, np.array(profiles)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -81,3 +81,20 @@ def test_expand_list():
     expanded_list = expand_list(test_values, 10)
     assert len(expanded_list) == 11
     assert np.allclose(expected_values, expanded_list)
+
+
+def test_rib_rotation():
+    """"""
+    original_points = np.array(
+        [[[1, 1, 1], [1, 2, 1], [3, 2, 0]], [[1, 1, 1], [1, 2, 1], [3, 2, 0]]]
+    )
+    rotation_angle = 90
+    rotated_points_exp = np.array(
+        [
+            [[-1, 1, 1], [-2, 1, 1], [-2, 3, 0]],
+            [[-1, 1, 1], [-2, 1, 1], [-2, 3, 0]],
+        ]
+    )
+    rotated_points = rotate_ribs(original_points, rotation_angle)
+    print(rotated_points)
+    assert np.allclose(rotated_points, rotated_points_exp)


### PR DESCRIPTION
The approach I have taken is to create a class that has the same methods and behavior as those that we use from VMECData.

In this case, the custom first wall is defined in R-Z coordinates in a manner similar to how we define ribs. By assuming that the points on each rib are spaced evenly in the poloidal direction, a continuous surface which is a function of poloidal and toroidal angle can be created by interpolation of those points.

I was thinking we could set something up where there is a base class for representing the innermost surface, call it ReferenceSurface() or something along those lines, then we could have two classes that inherit from it, one that works with VMEC data and one that works with R-Z data, and by doing so we could have some infrastructure set up to possibly extend to other formats if it becomes necessary.

For right now I just added a vmec2xyz() method to my new KisslingerSurface() class that allows this class to be slotted in in place of a VMECData() object as a demonstration. I've included custom_geometry_example.py for a bit of context.

Addresses #108 