### PR TITLE
Add method to convert DAGMC volume to STEP

### DIFF
--- a/parastell/cubit_utils.py
+++ b/parastell/cubit_utils.py
@@ -20,7 +20,7 @@ def check_cubit_installation():
 
 
 def init_cubit():
-    """Initializes Coreform Cubit with the DAGMC plugin."""
+    """Initializes Coreform Cubit."""
     global cubit
     import cubit
 

--- a/parastell/utils.py
+++ b/parastell/utils.py
@@ -321,7 +321,7 @@ def combine_dagmc_models(models_to_merge):
 
 
 def stl_surfaces_to_cq_solid(stl_file_paths, tolerance=0.001):
-    """ "Create a solid volume in CadQuery from STL files defining the surfaces
+    """Create a solid volume in CadQuery from STL files defining the surfaces
     of a watertight volume. The resulting volume should have surfaces that
     exactly match the STL files provided. Useful for obtaining CAD
     representations of volumes in DAGMC models.
@@ -334,7 +334,7 @@ def stl_surfaces_to_cq_solid(stl_file_paths, tolerance=0.001):
 
     Returns:
         cq_solid (CadQuery Solid): Solid volume with surfaces defined by the
-            the provided STL files.
+            the triangles in the provided STL files.
     """
     sewer = BRepBuilderAPI_Sewing(tolerance)
 
@@ -391,8 +391,9 @@ def dagmc_volume_to_step(
     if num_tris != num_faces:
         raise ValueError(
             f"Number of faces in the STEP file ({num_faces}) does"
-            "not match the number of triangles in the STL files"
-            f"({num_tris})"
+            "not match the number of triangles in the DAGMC volume"
+            f"({num_tris}). Please verify that your geometry is valid or use"
+            "a tighter tolerance."
         )
 
     cq_solid.exportStep(str(Path(step_file_path).with_suffix(".step")))

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -85,10 +85,10 @@ def test_expand_list():
 
 def test_stl_surfaces_to_cq_solid():
     """Tests utils.stl_surface_to_cq_solid() to verify that the correct number
-    of faces are present on the CadQuery solid representation of the DAGMC
-    volume, and that the volume of the DAGMC volume and the CadQuery solid
-    are equal by testing if:
-      * the number of triangle handles beloning to the DAGMC volume is the
+    of faces are present in the CadQuery solid representation of the DAGMC
+    volume, and that the volume of the DAGMC volume was preserved in the
+    CadQuery solid by checking if:
+      * the number of triangle handles belonging to the DAGMC volume is the
         same as the number of faces belonging to the CadQuery solid.
       * the volume of the DAGMC volume is close to the volume of the CadQuery
         solid (using math.isclose()).


### PR DESCRIPTION
Closes #202 

Two methods are added to `parastell.utils`, one which reads STL files defining the surfaces of the volume to be converted and returns a CadQuery Solid defined by those surfaces, and another than streamlines the process by taking a PyDAGMC DAGModel object and a volume ID and writing the corresponding CadQuery Solid to STEP.