### PR TITLE
Add open-source volumetric meshing routines

### DIFF
--- a/Examples/custom_first_wall_profile_example.py
+++ b/Examples/custom_first_wall_profile_example.py
@@ -76,7 +76,7 @@ stellarator.construct_invessel_build(
     toroidal_angles, poloidal_angles, wall_s, radial_build_dict, scale=1
 )
 # Export in-vessel component files
-stellarator.export_invessel_build(export_dir=export_dir)
+stellarator.export_invessel_build_step(export_dir=export_dir)
 
 # Define build parameters for magnet coils
 coils_file = "coils.example"
@@ -88,11 +88,9 @@ stellarator.construct_magnets_from_filaments(
     coils_file, width, thickness, toroidal_extent, sample_mod=6
 )
 # Export magnet files
-stellarator.export_magnets(
-    step_filename="magnets",
-    export_mesh=True,
-    mesh_filename="magnet_mesh",
-    export_dir=export_dir,
+stellarator.export_magnets_step(filename="magnets", export_dir=export_dir)
+stellarator.export_magnet_mesh_cubit(
+    filename="magnet_mesh", export_dir=export_dir
 )
 
 # Define source mesh parameters

--- a/Examples/custom_source_example.py
+++ b/Examples/custom_source_example.py
@@ -39,5 +39,5 @@ source_mesh_obj.create_vertices()
 source_mesh_obj.create_mesh()
 
 # export and convert to vtk for visualization
-source_mesh_obj.export_mesh()
+source_mesh_obj.export_mesh("source_mesh.h5m")
 subprocess.run("mbconvert source_mesh.h5m source_mesh.vtk", shell=True)

--- a/Examples/parastell_cad_to_dagmc_example.py
+++ b/Examples/parastell_cad_to_dagmc_example.py
@@ -48,7 +48,7 @@ stellarator.construct_invessel_build(
     toroidal_angles, poloidal_angles, wall_s, radial_build_dict
 )
 # Export in-vessel component files
-stellarator.export_invessel_build(export_dir=export_dir)
+stellarator.export_invessel_build_step(export_dir=export_dir)
 
 # Define build parameters for magnet coils
 coils_file = "coils.example"
@@ -60,8 +60,8 @@ stellarator.construct_magnets_from_filaments(
     coils_file, width, thickness, toroidal_extent, sample_mod=6
 )
 # Export magnet files
-stellarator.export_magnets(
-    step_filename="magnets",
+stellarator.export_magnets_step(
+    filename="magnet_set",
     export_dir=export_dir,
 )
 

--- a/Examples/parastell_cad_to_dagmc_example.py
+++ b/Examples/parastell_cad_to_dagmc_example.py
@@ -49,6 +49,17 @@ stellarator.construct_invessel_build(
 )
 # Export in-vessel component files
 stellarator.export_invessel_build_step(export_dir=export_dir)
+stellarator.export_invessel_build_mesh_gmsh(
+    [
+        "chamber",
+        "first_wall",
+        "breeder",
+        "back_wall",
+        "shield",
+        "vacuum_vessel",
+    ],
+    "weight_window_mesh",
+)
 
 # Define build parameters for magnet coils
 coils_file = "coils.example"
@@ -63,6 +74,9 @@ stellarator.construct_magnets_from_filaments(
 stellarator.export_magnets_step(
     filename="magnet_set",
     export_dir=export_dir,
+)
+stellarator.export_magnet_mesh_gmsh(
+    filename="magnet_mesh", export_dir=export_dir
 )
 
 # Define source mesh parameters

--- a/Examples/parastell_cubit_example.py
+++ b/Examples/parastell_cubit_example.py
@@ -49,6 +49,17 @@ stellarator.construct_invessel_build(
 )
 # Export in-vessel component files
 stellarator.export_invessel_build_step(export_dir=export_dir)
+stellarator.export_invessel_build_mesh_cubit(
+    [
+        "chamber",
+        "first_wall",
+        "breeder",
+        "back_wall",
+        "shield",
+        "vacuum_vessel",
+    ],
+    "weight_window_mesh",
+)
 
 # Define build parameters for magnet coils
 coils_file = "coils.example"

--- a/Examples/parastell_cubit_example.py
+++ b/Examples/parastell_cubit_example.py
@@ -48,7 +48,7 @@ stellarator.construct_invessel_build(
     toroidal_angles, poloidal_angles, wall_s, radial_build_dict
 )
 # Export in-vessel component files
-stellarator.export_invessel_build(export_dir=export_dir)
+stellarator.export_invessel_build_step(export_dir=export_dir)
 
 # Define build parameters for magnet coils
 coils_file = "coils.example"
@@ -60,11 +60,9 @@ stellarator.construct_magnets_from_filaments(
     coils_file, width, thickness, toroidal_extent, sample_mod=6
 )
 # Export magnet files
-stellarator.export_magnets(
-    step_filename="magnets",
-    export_mesh=True,
-    mesh_filename="magnet_mesh",
-    export_dir=export_dir,
+stellarator.export_magnets_step(filename="magnet_set", export_dir=export_dir)
+stellarator.export_magnet_mesh_cubit(
+    filename="magnet_mesh", export_dir=export_dir
 )
 
 # Define source mesh parameters

--- a/Examples/parastell_pydagmc_example.py
+++ b/Examples/parastell_pydagmc_example.py
@@ -68,11 +68,7 @@ toroidal_extent = 90.0
 stellarator.construct_magnets_from_filaments(
     coils_file, width, thickness, toroidal_extent, sample_mod=6
 )
-stellarator.export_magnets(
-    step_filename="magnets",
-    export_mesh=False,
-    export_dir=export_dir,
-)
+stellarator.export_magnets_step(filename="magnets", export_dir=export_dir)
 
 stellarator.build_pydagmc_model(
     magnet_exporter="cad_to_dagmc", max_mesh_size=60

--- a/Examples/parastell_pydagmc_example.py
+++ b/Examples/parastell_pydagmc_example.py
@@ -58,6 +58,10 @@ stellarator.construct_invessel_build(
     num_ribs=num_ribs,
     num_rib_pts=num_rib_pts,
 )
+# Export in-vessel component files
+stellarator.export_invessel_build_mesh_moab(
+    "vacuum_vessel", "vacuum_vessel_tally_mesh"
+)
 
 # Define build parameters for magnet coils
 coils_file = "coils.example"

--- a/Examples/radial_distance_example.py
+++ b/Examples/radial_distance_example.py
@@ -90,14 +90,14 @@ stellarator.construct_invessel_build(
     num_rib_pts=61,
 )
 # Export in-vessel component files
-stellarator.export_invessel_build()
+stellarator.export_invessel_build_step()
 
 # Construct magnets
 stellarator.construct_magnets_from_filaments(
     coils_file, width, thickness, toroidal_extent, sample_mod=6
 )
 # Export magnet files
-stellarator.export_magnets()
+stellarator.export_magnets_step()
 
 # Define source mesh parameters
 mesh_size = (11, 81, 61)

--- a/parastell/cubit_utils.py
+++ b/parastell/cubit_utils.py
@@ -1,5 +1,6 @@
 from pathlib import Path
-import subprocess
+
+from pymoab import core
 
 initialized = False
 
@@ -127,7 +128,11 @@ def export_mesh_cubit(filename, export_dir="", delete_upon_export=True):
     h5m_path = Path(export_dir) / Path(filename).with_suffix(".h5m")
 
     cubit.cmd(f'export mesh "{exo_path}" overwrite')
-    subprocess.run(f"mbconvert {exo_path} {h5m_path}", shell=True)
+
+    mesh_mbc = core.Core()
+    mesh_mbc.load_file(str(exo_path))
+    mesh_mbc.write_file(str(h5m_path))
+
     Path.unlink(exo_path)
 
     # Delete any meshes present to prevent inclusion in future Cubit mesh

--- a/parastell/invessel_build.py
+++ b/parastell/invessel_build.py
@@ -731,7 +731,7 @@ class InVesselBuild(object):
         surfaces = [self.Surfaces[surface_keys[component_idx - 1]]]
         surfaces.append(self.Surfaces[component])
 
-        self.moab_mesh = InVesselComponentMesh(surfaces)
+        self.moab_mesh = InVesselComponentMesh(surfaces, self._logger)
 
         self.moab_mesh.create_vertices()
         self.moab_mesh.create_mesh()
@@ -745,7 +745,6 @@ class InVesselBuild(object):
             export_dir (str): directory to which to export the h5m output file
                 (defaults to empty string).
         """
-        self._logger.info("Exporting mesh H5M file for in-vessel component...")
         self.moab_mesh.export_mesh(filename, export_dir=export_dir)
 
     def mesh_components_gmsh(
@@ -863,9 +862,7 @@ class InVesselBuild(object):
             export_dir (str): directory to which to export the h5m output file
                 (defaults to empty string).
         """
-        self._logger.info(
-            "Exporting mesh H5M file for in-vessel component(s)..."
-        )
+        self._logger.info("Exporting mesh H5M file...")
 
         vtk_path = Path(export_dir) / Path(filename).with_suffix(".vtk")
         moab_path = vtk_path.with_suffix(".h5m")
@@ -917,9 +914,7 @@ class InVesselBuild(object):
             export_dir (str): directory to which to export the h5m output file
                 (defaults to empty string).
         """
-        self._logger.info(
-            "Exporting mesh H5M file for in-vessel component(s)..."
-        )
+        self._logger.info("Exporting mesh H5M file...")
 
         export_mesh_cubit(
             filename=filename,
@@ -1124,10 +1119,12 @@ class InVesselComponentMesh(ToroidalMesh):
     Arguments:
         surfaces (list of object): the component's two Surface class objects,
             ordered radially outward.
+        logger (object): logger object (defaults to None). If no logger is
+            supplied, a default logger will be instantiated.
     """
 
-    def __init__(self, surfaces):
-        super().__init__()
+    def __init__(self, surfaces, logger=None):
+        super().__init__(logger=logger)
 
         self.surfaces = surfaces
 

--- a/parastell/invessel_build.py
+++ b/parastell/invessel_build.py
@@ -892,6 +892,8 @@ class InVesselBuild(object):
             components (array of str): array containing the names of the
                 in-vessel components to be meshed.
         """
+        # These parameters are taken directly from Gmsh documentation (see
+        # tutorial t13)
         gmsh.onelab.set(
             """[
             {

--- a/parastell/invessel_build.py
+++ b/parastell/invessel_build.py
@@ -1189,17 +1189,6 @@ class InVesselComponentMesh(ToroidalMesh):
 
         return id
 
-    def export_mesh(self, filename, export_dir=""):
-        """Exports a tetrahedral mesh of in-vessel component volumes in H5M
-        format via MOAB.
-
-        Arguments:
-            filename (str): name of H5M output file.
-            export_dir (str): directory to which to export the h5m output file
-                (defaults to empty string).
-        """
-        self.export(filename, export_dir=export_dir)
-
 
 class RadialBuild(object):
     """Parametrically defines ParaStell in-vessel component geometries.

--- a/parastell/invessel_build.py
+++ b/parastell/invessel_build.py
@@ -746,7 +746,6 @@ class InVesselBuild(object):
             for rib in surface.Ribs:
                 coords.extend(rib.rib_loci)
         coords = np.array(coords)
-        print(coords.shape)
 
         self.verts = self.mesh_mbc.create_vertices(coords)
 

--- a/parastell/invessel_build.py
+++ b/parastell/invessel_build.py
@@ -733,11 +733,8 @@ class InVesselBuild(object):
         surfaces = []
         surface_keys = list(self.Surfaces.keys())
 
-        for i, key in enumerate(surface_keys[:-1]):
-            # Inner surface of given component = outer surface of inner
-            # component
-            if surface_keys[i + 1] == component:
-                surfaces.append(self.Surfaces[key])
+        component_index = surface_keys.index(component)
+        surfaces = [self.Surfaces(surface_keys[component_index - 1])]
         surfaces.append(self.Surfaces[component])
 
         coords = []
@@ -979,7 +976,7 @@ class InVesselBuild(object):
         )
 
         vtk_path = str(Path(export_dir) / Path(filename).with_suffix(".vtk"))
-        moab_path = Path(export_dir) / Path(filename).with_suffix(".h5m")
+        moab_path = vtk_path.with_suffix(".h5m")
 
         gmsh.write(vtk_path)
 

--- a/parastell/invessel_build.py
+++ b/parastell/invessel_build.py
@@ -710,24 +710,23 @@ class InVesselBuild(object):
 
         return solids, mat_tags
 
-    def export_component_mesh(
-        self, components, filename, mesh_size=5, import_dir="", export_dir=""
-    ):
-        """Creates a tetrahedral mesh of an in-vessel component volume
-        via Coreform Cubit and exports it as H5M file.
+    def mesh_components_cubit(self, components, mesh_size=5, import_dir=""):
+        """Creates a tetrahedral mesh of in-vessel component volumes via
+        Coreform Cubit.
 
         Arguments:
             components (array of strings): array containing the name
                 of the in-vessel components to be meshed.
-            filename (str): name of H5M output file, excluding '.h5m' extension.
             mesh_size (float): controls the size of the mesh. Takes values
                 between 1.0 (finer) and 10.0 (coarser) (optional, defaults to
                 5.0).
             import_dir (str): directory containing the STEP file of
                 the in-vessel component (optional, defaults to empty string).
-            export_dir (str): directory to which to export the h5m
-                output file (optional, defaults to empty string).
         """
+        self._logger.info(
+            "Generating tetrahedral mesh of in-vessel component(s)..."
+        )
+
         create_new_cubit_instance()
 
         volume_ids = []
@@ -737,13 +736,25 @@ class InVesselBuild(object):
             volume_ids.append(volume_id)
 
         mesh_volume_auto_factor(volume_ids, mesh_size=mesh_size)
+
+    def export_mesh_cubit(self, filename, export_dir=""):
+        """Exports a tetrahedral mesh of in-vessel component volumes in H5M
+        format via Coreform Cubit and MOAB.
+
+        Arguments:
+            filename (str): name of H5M output file.
+            export_dir (str): directory to which to export the h5m output file
+                (optional, defaults to empty string).
+        """
+        self._logger.info(
+            "Exporting mesh H5M file for in-vessel component(s)..."
+        )
+
         export_mesh_cubit(
             filename=filename,
             export_dir=export_dir,
             delete_upon_export=True,
         )
-
-        create_new_cubit_instance()
 
 
 class Surface(object):

--- a/parastell/invessel_build.py
+++ b/parastell/invessel_build.py
@@ -305,7 +305,7 @@ class InVesselBuild(object):
 
         self.repeat = 0
         self.num_ribs = 61
-        self.num_rib_pts = 67
+        self.num_rib_pts = 61
         self.scale = m2cm
         self.use_pydagmc = False
 
@@ -409,6 +409,10 @@ class InVesselBuild(object):
         self._poloidal_angles_exp = np.deg2rad(
             expand_list(self.radial_build.poloidal_angles, self.num_rib_pts)
         )
+
+        # Store actual number of ribs and rib points
+        self._num_ribs = len(self._toroidal_angles_exp)
+        self._num_rib_pts = len(self._poloidal_angles_exp)
 
         offset_mat = np.zeros(
             (
@@ -712,7 +716,7 @@ class InVesselBuild(object):
 
         return solids, mat_tags
 
-    def mesh_components_moab(self, component):
+    def mesh_component_moab(self, component):
         """Creates a tetrahedral mesh of a single in-vessel component volume
         via MOAB. This mesh is created using the point cloud of the specified
         component and as such, the mesh will be one tetrahedron thick.
@@ -747,8 +751,8 @@ class InVesselBuild(object):
         self.mesh_set = self.mesh_mbc.create_meshset()
         self.mesh_mbc.add_entity(self.mesh_set, self.verts)
 
-        for toroidal_idx in range(self.num_ribs - 1):
-            for poloidal_idx in range(self.num_rib_pts - 1):
+        for toroidal_idx in range(self._num_ribs - 1):
+            for poloidal_idx in range(self._num_rib_pts - 1):
                 self._create_tets_from_hex(poloidal_idx, toroidal_idx)
 
     def _create_tets_from_hex(self, poloidal_idx, toroidal_idx):
@@ -814,14 +818,14 @@ class InVesselBuild(object):
         """
         surface_idx, poloidal_idx, toroidal_idx = vertex_idx
 
-        verts_per_surface = self.num_ribs * self.num_rib_pts
+        verts_per_surface = self._num_ribs * self._num_rib_pts
         surface_offset = surface_idx * verts_per_surface
 
-        toroidal_offset = toroidal_idx * self.num_rib_pts
+        toroidal_offset = toroidal_idx * self._num_rib_pts
 
         poloidal_offset = poloidal_idx
         # Wrap around if poloidal angle is 2*pi
-        if poloidal_idx == self.num_rib_pts - 1:
+        if poloidal_idx == self._num_rib_pts - 1:
             poloidal_offset = 0
 
         id = surface_offset + toroidal_offset + poloidal_offset

--- a/parastell/invessel_build.py
+++ b/parastell/invessel_build.py
@@ -794,28 +794,15 @@ class InVesselBuild(object):
         # first, ordered clockwise relative to the thumb, followed by the
         # remaining vertex at the end of the thumb.
         # See Moreno, Bader, Wilson 2024 for hexahedron splitting
-        canonical_ordering_schemes = [
-            [
-                [idx_list[0], idx_list[3], idx_list[1], idx_list[4]],
-                [idx_list[1], idx_list[3], idx_list[2], idx_list[6]],
-                [idx_list[1], idx_list[4], idx_list[6], idx_list[5]],
-                [idx_list[3], idx_list[6], idx_list[4], idx_list[7]],
-                [idx_list[1], idx_list[3], idx_list[6], idx_list[4]],
-            ],
-            [
-                [idx_list[0], idx_list[2], idx_list[1], idx_list[5]],
-                [idx_list[0], idx_list[3], idx_list[2], idx_list[7]],
-                [idx_list[0], idx_list[7], idx_list[5], idx_list[4]],
-                [idx_list[7], idx_list[2], idx_list[5], idx_list[6]],
-                [idx_list[0], idx_list[2], idx_list[5], idx_list[7]],
-            ],
+        hex_to_tets_mapping = [
+            [idx_list[0], idx_list[3], idx_list[1], idx_list[4]],
+            [idx_list[1], idx_list[3], idx_list[2], idx_list[6]],
+            [idx_list[1], idx_list[4], idx_list[6], idx_list[5]],
+            [idx_list[3], idx_list[6], idx_list[4], idx_list[7]],
+            [idx_list[1], idx_list[3], idx_list[6], idx_list[4]],
         ]
 
-        # Alternate canonical ordering schemes defining hexahedron splitting to
-        # avoid gaps and overlaps between non-planar hexahedron faces
-        scheme_idx = 0
-
-        for vertex_ids in canonical_ordering_schemes[scheme_idx]:
+        for vertex_ids in hex_to_tets_mapping:
             self._create_tet(vertex_ids)
 
     def _get_vertex_id(self, vertex_idx):

--- a/parastell/invessel_build.py
+++ b/parastell/invessel_build.py
@@ -734,7 +734,7 @@ class InVesselBuild(object):
         surface_keys = list(self.Surfaces.keys())
 
         component_index = surface_keys.index(component)
-        surfaces = [self.Surfaces(surface_keys[component_index - 1])]
+        surfaces = [self.Surfaces[surface_keys[component_index - 1]]]
         surfaces.append(self.Surfaces[component])
 
         coords = []

--- a/parastell/invessel_build.py
+++ b/parastell/invessel_build.py
@@ -16,6 +16,7 @@ from pymoab import core, types
 
 from . import log
 from .cubit_utils import (
+    create_new_cubit_instance,
     import_step_cubit,
     export_mesh_cubit,
     orient_spline_surfaces,
@@ -710,7 +711,7 @@ class InVesselBuild(object):
         return solids, mat_tags
 
     def export_component_mesh(
-        self, components, mesh_size=5, import_dir="", export_dir=""
+        self, components, filename, mesh_size=5, import_dir="", export_dir=""
     ):
         """Creates a tetrahedral mesh of an in-vessel component volume
         via Coreform Cubit and exports it as H5M file.
@@ -718,6 +719,7 @@ class InVesselBuild(object):
         Arguments:
             components (array of strings): array containing the name
                 of the in-vessel components to be meshed.
+            filename (str): name of H5M output file, excluding '.h5m' extension.
             mesh_size (float): controls the size of the mesh. Takes values
                 between 1.0 (finer) and 10.0 (coarser) (optional, defaults to
                 5.0).
@@ -726,14 +728,22 @@ class InVesselBuild(object):
             export_dir (str): directory to which to export the h5m
                 output file (optional, defaults to empty string).
         """
+        create_new_cubit_instance()
+
+        volume_ids = []
+
         for component in components:
-            vol_id = import_step_cubit(component, import_dir)
-            mesh_volume_auto_factor([vol_id], mesh_size=mesh_size)
-            export_mesh_cubit(
-                filename=component,
-                export_dir=export_dir,
-                delete_upon_export=True,
-            )
+            volume_id = import_step_cubit(component, import_dir)
+            volume_ids.append(volume_id)
+
+        mesh_volume_auto_factor(volume_ids, mesh_size=mesh_size)
+        export_mesh_cubit(
+            filename=filename,
+            export_dir=export_dir,
+            delete_upon_export=True,
+        )
+
+        create_new_cubit_instance()
 
 
 class Surface(object):

--- a/parastell/magnet_coils.py
+++ b/parastell/magnet_coils.py
@@ -104,7 +104,7 @@ class MagnetSet(ABC):
             export_dir (str): directory to which to export the H5M output file
                 (defaults to empty string).
         """
-        self._logger.info("Exporting mesh H5M file for magnet coils...")
+        self._logger.info("Exporting mesh H5M file...")
 
         export_mesh_cubit(
             filename=filename,
@@ -145,7 +145,7 @@ class MagnetSet(ABC):
             export_dir (str): directory to which to export the h5m output file
                 (defaults to empty string).
         """
-        self._logger.info("Exporting mesh H5M file for magnets...")
+        self._logger.info("Exporting mesh H5M file...")
 
         vtk_path = Path(export_dir) / Path(filename).with_suffix(".vtk")
         moab_path = vtk_path.with_suffix(".h5m")

--- a/parastell/magnet_coils.py
+++ b/parastell/magnet_coils.py
@@ -148,7 +148,7 @@ class MagnetSet(ABC):
         self._logger.info("Exporting mesh H5M file for magnets...")
 
         vtk_path = str(Path(export_dir) / Path(filename).with_suffix(".vtk"))
-        moab_path = Path(export_dir) / Path(filename).with_suffix(".h5m")
+        moab_path = vtk_path.with_suffix(".h5m")
 
         gmsh.write(vtk_path)
 

--- a/parastell/parastell.py
+++ b/parastell/parastell.py
@@ -200,8 +200,10 @@ class Stellarator(object):
     def export_invessel_build_mesh_moab(
         self, component, filename, export_dir=""
     ):
-        """Creates a tetrahedral mesh of in-vessel component volumes via
-        MOAB and exports the mesh as a H5M file.
+        """Creates a tetrahedral mesh of a single in-vessel component volume
+        via MOAB and exports the mesh as a H5M file. Note that if this method
+        is used for adjacent components, the resultant meshes may have
+        overlapping tetrahedra.
 
         Arguments:
             component (str): name of the in-vessel component to be meshed.

--- a/parastell/parastell.py
+++ b/parastell/parastell.py
@@ -209,8 +209,7 @@ class Stellarator(object):
             export_dir (str): directory to which to export the h5m output file
                 (defaults to empty string).
         """
-        self._logger.info("Exporting in-vessel components mesh via MOAB...")
-        self.invessel_build.mesh_components_moab(component)
+        self.invessel_build.mesh_component_moab(component)
         self.invessel_build.export_mesh_moab(filename, export_dir=export_dir)
 
     def export_invessel_build_mesh_gmsh(
@@ -235,7 +234,6 @@ class Stellarator(object):
             export_dir (str): directory to which to export the h5m
                 output file (optional, defaults to empty string).
         """
-        self._logger.info("Exporting in-vessel components mesh via Gmsh...")
         self.invessel_build.mesh_components_gmsh(
             components,
             min_mesh_size=min_mesh_size,
@@ -258,9 +256,6 @@ class Stellarator(object):
             export_dir (str): directory to which to export the h5m
                 output file (optional, defaults to empty string).
         """
-        self._logger.info(
-            "Exporting in-vessel components mesh via Coreform Cubit..."
-        )
         self.invessel_build.mesh_components_cubit(
             components,
             mesh_size=mesh_size,

--- a/parastell/parastell.py
+++ b/parastell/parastell.py
@@ -214,8 +214,8 @@ class Stellarator(object):
 
     def export_invessel_build_mesh_gmsh(
         self,
-        filename,
         components,
+        filename,
         min_mesh_size=5.0,
         max_mesh_size=20.0,
         export_dir="",
@@ -224,9 +224,9 @@ class Stellarator(object):
         Gmsh and exports the mesh as a H5M file.
 
         Arguments:
-            filename (str): name of H5M output file.
             components (array of str): array containing the names of the
                 in-vessel components to be meshed.
+            filename (str): name of H5M output file.
             min_mesh_size (float): minimum size of mesh elements (defaults to
                 5.0).
             max_mesh_size (float): maximum size of mesh elements (defaults to
@@ -242,15 +242,15 @@ class Stellarator(object):
         self.invessel_build.export_mesh_gmsh(filename, export_dir=export_dir)
 
     def export_invessel_build_mesh_cubit(
-        self, filename, components, mesh_size=5, export_dir=""
+        self, components, filename, mesh_size=5, export_dir=""
     ):
         """Creates a tetrahedral mesh of in-vessel component volumes via
         Coreform Cubit and exports the mesh as a H5M file.
 
         Arguments:
-            filename (str): name of H5M output file.
             components (array of str): array containing the names of the
                 in-vessel components to be meshed.
+            filename (str): name of H5M output file.
             mesh_size (int): controls the size of the mesh. Takes values
                 between 1 (finer) and 10 (coarser) (optional, defaults to 5).
             export_dir (str): directory to which to export the h5m

--- a/parastell/parastell.py
+++ b/parastell/parastell.py
@@ -197,6 +197,22 @@ class Stellarator(object):
         """
         self.invessel_build.export_step(export_dir=export_dir)
 
+    def export_invessel_build_mesh_moab(
+        self, component, filename, export_dir=""
+    ):
+        """Creates a tetrahedral mesh of in-vessel component volumes via
+        MOAB and exports the mesh as a H5M file.
+
+        Arguments:
+            component (str): name of the in-vessel component to be meshed.
+            filename (str): name of H5M output file.
+            export_dir (str): directory to which to export the h5m output file
+                (defaults to empty string).
+        """
+        self._logger.info("Exporting in-vessel components mesh via MOAB...")
+        self.invessel_build.mesh_components_moab(component)
+        self.invessel_build.export_mesh_moab(filename, export_dir=export_dir)
+
     def export_invessel_build_mesh_cubit(
         self, filename, components, mesh_size=5, export_dir=""
     ):
@@ -214,7 +230,9 @@ class Stellarator(object):
             export_dir (str): directory to which to export the h5m
                 output file (optional, defaults to empty string).
         """
-        self._logger.info("Exporting in-vessel components mesh...")
+        self._logger.info(
+            "Exporting in-vessel components mesh via Coreform Cubit..."
+        )
         self.invessel_build.mesh_components_cubit(
             components,
             mesh_size=mesh_size,
@@ -491,8 +509,8 @@ class Stellarator(object):
         self,
         filename="dagmc",
         export_dir="",
-        min_mesh_size=20,
-        max_mesh_size=50,
+        min_mesh_size=5.0,
+        max_mesh_size=20.0,
     ):
         """Exports DAGMC neutronics H5M file of ParaStell components via
         CAD-to-DAGMC.
@@ -503,9 +521,9 @@ class Stellarator(object):
             export_dir (str): directory to which to export DAGMC output file
                 (optional, defaults to empty string).
             min_mesh_size (float): minimum size of mesh elements (defaults to
-                20).
+                5.0).
             max_mesh_size (float): maximum size of mesh elements (defaults to
-                50).
+                20.0).
         """
         self._logger.info(
             "Exporting DAGMC neutronics model with CAD-to-DAGMC ..."

--- a/parastell/parastell.py
+++ b/parastell/parastell.py
@@ -213,6 +213,36 @@ class Stellarator(object):
         self.invessel_build.mesh_components_moab(component)
         self.invessel_build.export_mesh_moab(filename, export_dir=export_dir)
 
+    def export_invessel_build_mesh_gmsh(
+        self,
+        filename,
+        components,
+        min_mesh_size=5.0,
+        max_mesh_size=20.0,
+        export_dir="",
+    ):
+        """Creates a tetrahedral mesh of in-vessel component volumes via
+        Gmsh and exports the mesh as a H5M file.
+
+        Arguments:
+            filename (str): name of H5M output file.
+            components (array of str): array containing the names of the
+                in-vessel components to be meshed.
+            min_mesh_size (float): minimum size of mesh elements (defaults to
+                5.0).
+            max_mesh_size (float): maximum size of mesh elements (defaults to
+                20.0).
+            export_dir (str): directory to which to export the h5m
+                output file (optional, defaults to empty string).
+        """
+        self._logger.info("Exporting in-vessel components mesh via Gmsh...")
+        self.invessel_build.mesh_components_gmsh(
+            components,
+            min_mesh_size=min_mesh_size,
+            max_mesh_size=max_mesh_size,
+        )
+        self.invessel_build.export_mesh_gmsh(filename, export_dir=export_dir)
+
     def export_invessel_build_mesh_cubit(
         self, filename, components, mesh_size=5, export_dir=""
     ):
@@ -221,12 +251,10 @@ class Stellarator(object):
 
         Arguments:
             filename (str): name of H5M output file.
-            components (array of strings): array containing the name
-                of the in-vessel components to be meshed.
+            components (array of str): array containing the names of the
+                in-vessel components to be meshed.
             mesh_size (int): controls the size of the mesh. Takes values
                 between 1 (finer) and 10 (coarser) (optional, defaults to 5).
-            import_dir (str): directory containing the STEP file of
-                the in-vessel component (optional, defaults to empty string).
             export_dir (str): directory to which to export the h5m
                 output file (optional, defaults to empty string).
         """

--- a/parastell/parastell.py
+++ b/parastell/parastell.py
@@ -188,7 +188,7 @@ class Stellarator(object):
         self.invessel_build.calculate_loci()
         self.invessel_build.generate_components()
 
-    def export_invessel_build(self, export_dir=""):
+    def export_invessel_build_step(self, export_dir=""):
         """Exports InVesselBuild component STEP files.
 
         Arguments:
@@ -197,13 +197,14 @@ class Stellarator(object):
         """
         self.invessel_build.export_step(export_dir=export_dir)
 
-    def export_invessel_component_mesh(
-        self, components, mesh_size=5, import_dir="", export_dir=""
+    def export_invessel_build_mesh_cubit(
+        self, filename, components, mesh_size=5, export_dir=""
     ):
-        """Creates a tetrahedral mesh of an in-vessel component volume
-        via Coreform Cubit and exports it as H5M file.
+        """Creates a tetrahedral mesh of in-vessel component volumes via
+        Coreform Cubit and exports the mesh as a H5M file.
 
         Arguments:
+            filename (str): name of H5M output file.
             components (array of strings): array containing the name
                 of the in-vessel components to be meshed.
             mesh_size (int): controls the size of the mesh. Takes values
@@ -214,9 +215,12 @@ class Stellarator(object):
                 output file (optional, defaults to empty string).
         """
         self._logger.info("Exporting in-vessel components mesh...")
-        self.invessel_build.export_component_mesh(
-            components, mesh_size, import_dir, export_dir
+        self.invessel_build.mesh_components_cubit(
+            components,
+            mesh_size=mesh_size,
+            import_dir=self.invessel_build.export_dir,
         )
+        self.invessel_build.export_mesh_cubit(filename, export_dir=export_dir)
 
     def construct_magnets_from_filaments(
         self, coils_file, width, thickness, toroidal_extent, **kwargs
@@ -271,44 +275,48 @@ class Stellarator(object):
             **kwargs,
         )
 
-    def export_magnets(
-        self,
-        step_filename="magnet_set",
-        export_mesh=False,
-        mesh_filename="magnet_mesh",
-        export_dir="",
-        **kwargs,
-    ):
-        """Export magnet components.
+    def export_magnets_step(self, filename="magnet_set", export_dir=""):
+        """Export STEP file of magnet set.
 
         Arguments:
-            step_filename (str): name of STEP export output file, excluding
-                '.step' extension (optional, optional, defaults to
-                'magnet_set').
-            export_mesh (bool): flag to indicate tetrahedral mesh generation
-                for magnet volumes (optional, defaults to False).
-            mesh_filename (str): name of tetrahedral mesh H5M file, excluding
-                '.h5m' extension (optional, defaults to 'magnet_mesh').
+            filename (str): name of STEP export output file (optional, defaults
+                to 'magnet_set').
             export_dir (str): directory to which to export output files
                 (optional, defaults to empty string).
+        """
+        self.magnet_set.export_step(filename=filename, export_dir=export_dir)
 
-        Optional attributes:
+    def export_magnet_mesh_cubit(
+        self,
+        filename="magnet_mesh",
+        min_size=20.0,
+        max_size=50.0,
+        max_gradient=1.5,
+        export_dir="",
+    ):
+        """Creates a tetrahedral mesh of magnet volumes via Coreform Cubit and
+        exports the mesh as a H5M file.
+
+        Arguments:
+            filename (str): name of tetrahedral mesh H5M file (optional,
+                defaults to 'magnet_mesh').
             min_size (float): minimum size of magnet mesh elements (defaults to
                 20.0).
             max_size (float): maximum size of magnet mesh elements (defaults to
                 50.0).
             max_gradient (float): maximum transition in magnet mesh element
                 size (defaults to 1.5).
+            export_dir (str): directory to which to export output files
+                (optional, defaults to empty string).
         """
-        self.magnet_set.export_step(
-            step_filename=step_filename, export_dir=export_dir
+        self.magnet_set.mesh_magnets_cubit(
+            min_size=min_size,
+            max_size=max_size,
+            max_gradient=max_gradient,
         )
-
-        if export_mesh:
-            self.magnet_set.mesh_magnets(**kwargs)
-            self.magnet_set.export_mesh(
-                mesh_filename=mesh_filename, export_dir=export_dir
-            )
+        self.magnet_set.export_mesh_cubit(
+            filename=filename, export_dir=export_dir
+        )
 
     def construct_source_mesh(self, mesh_size, toroidal_extent, **kwargs):
         """Constructs SourceMesh class object.

--- a/parastell/parastell.py
+++ b/parastell/parastell.py
@@ -339,16 +339,16 @@ class Stellarator(object):
         exports the mesh as a H5M file.
 
         Arguments:
-            filename (str): name of tetrahedral mesh H5M file (optional,
-                defaults to 'magnet_mesh').
+            filename (str): name of H5M output file (defaults to
+                'magnet_mesh').
             min_size (float): minimum size of magnet mesh elements (defaults to
                 20.0).
             max_size (float): maximum size of magnet mesh elements (defaults to
                 50.0).
             max_gradient (float): maximum transition in magnet mesh element
                 size (defaults to 1.5).
-            export_dir (str): directory to which to export output files
-                (optional, defaults to empty string).
+            export_dir (str): directory to which to export the h5m output file
+                (defaults to empty string).
         """
         self.magnet_set.mesh_magnets_cubit(
             min_size=min_size,
@@ -356,6 +356,34 @@ class Stellarator(object):
             max_gradient=max_gradient,
         )
         self.magnet_set.export_mesh_cubit(
+            filename=filename, export_dir=export_dir
+        )
+
+    def export_magnet_mesh_gmsh(
+        self,
+        filename="magnet_mesh",
+        min_mesh_size=20.0,
+        max_mesh_size=50.0,
+        export_dir="",
+    ):
+        """Creates a tetrahedral mesh of magnet volumes via Coreform Cubit and
+        exports the mesh as a H5M file.
+
+        Arguments:
+            filename (str): name of H5M output file (defaults to
+                'magnet_mesh').
+            min_mesh_size (float): minimum size of mesh elements (defaults to
+                5.0).
+            max_mesh_size (float): maximum size of mesh elements (defaults to
+                20.0).
+            export_dir (str): directory to which to export the h5m output file
+                (defaults to empty string).
+        """
+        self.magnet_set.mesh_magnets_gmsh(
+            min_mesh_size=min_mesh_size,
+            max_mesh_size=max_mesh_size,
+        )
+        self.magnet_set.export_mesh_gmsh(
             filename=filename, export_dir=export_dir
         )
 

--- a/parastell/source_mesh.py
+++ b/parastell/source_mesh.py
@@ -403,7 +403,8 @@ class SourceMesh(ToroidalMesh):
 
     def export_mesh(self, filename="source_mesh", export_dir=""):
         """Use PyMOAB interface to write source mesh with source strengths
-        tagged.
+        tagged. This method overwrites the "export_mesh" method from the
+        ToroidalMesh class, in order to include logging output.
 
         Arguments:
             filename: name of H5M output file, excluding '.h5m' extension
@@ -413,7 +414,8 @@ class SourceMesh(ToroidalMesh):
         """
         self._logger.info("Exporting source mesh H5M file...")
 
-        self.export(filename, export_dir=export_dir)
+        export_path = Path(export_dir) / Path(filename).with_suffix(".h5m")
+        self.mbc.write_file(str(export_path))
 
 
 def parse_args():

--- a/parastell/source_mesh.py
+++ b/parastell/source_mesh.py
@@ -110,9 +110,8 @@ class SourceMesh(ToroidalMesh):
     def __init__(
         self, vmec_obj, mesh_size, toroidal_extent, logger=None, **kwargs
     ):
-        super().__init__()
+        super().__init__(logger=logger)
 
-        self.logger = logger
         self.vmec_obj = vmec_obj
         self.num_cfs_pts = mesh_size[0]
         self.num_poloidal_pts = mesh_size[1]
@@ -184,14 +183,6 @@ class SourceMesh(ToroidalMesh):
             raise e
 
         self._toroidal_extent = angle
-
-    @property
-    def logger(self):
-        return self._logger
-
-    @logger.setter
-    def logger(self, logger_object):
-        self._logger = log.check_init(logger_object)
 
     def _add_tags_to_core(self):
         """Creates PyMOAB core instance with source strength tag.
@@ -401,22 +392,6 @@ class SourceMesh(ToroidalMesh):
                         self._compute_tet_data(tet_ids, tet)
                         for tet_ids, tet in zip(vertex_id_list, tets)
                     ]
-
-    def export_mesh(self, filename="source_mesh", export_dir=""):
-        """Use PyMOAB interface to write source mesh with source strengths
-        tagged. This method overwrites the "export_mesh" method from the
-        ToroidalMesh class, in order to include logging output.
-
-        Arguments:
-            filename: name of H5M output file, excluding '.h5m' extension
-                (defaults to 'source_mesh').
-            export_dir (str): directory to which to export the H5M output file
-                (defaults to empty string).
-        """
-        self._logger.info("Exporting source mesh H5M file...")
-
-        export_path = Path(export_dir) / Path(filename).with_suffix(".h5m")
-        self.mbc.write_file(str(export_path))
 
 
 def parse_args():

--- a/parastell/source_mesh.py
+++ b/parastell/source_mesh.py
@@ -93,8 +93,8 @@ class SourceMesh(object):
             of toroidal angles for planes of vertices.
         toroidal_extent (float): extent of source mesh in toroidal direction
             [deg].
-        logger (object): logger object (optional, defaults to None). If no
-            logger is supplied, a default logger will be instantiated.
+        logger (object): logger object (defaults to None). If no logger is
+            supplied, a default logger will be instantiated.
 
     Optional attributes:
         scale (float): a scaling factor between the units of VMEC and [cm]
@@ -532,9 +532,9 @@ class SourceMesh(object):
 
         Arguments:
             filename: name of H5M output file, excluding '.h5m' extension
-                (optional, defaults to 'source_mesh').
+                (defaults to 'source_mesh').
             export_dir (str): directory to which to export the H5M output file
-                (optional, defaults to empty string).
+                (defaults to empty string).
         """
         self._logger.info("Exporting source mesh H5M file...")
 

--- a/parastell/source_mesh.py
+++ b/parastell/source_mesh.py
@@ -284,8 +284,9 @@ class SourceMesh(ToroidalMesh):
         self.add_vertices(self.coords)
 
     def _compute_tet_data(self, tet_ids, tet):
-        """Computes neutron source strength for a tetrahedron using five-node
-        Gaussian quadrature.
+        """Computes tetrahedron neutron source strength, using five-node
+        Gaussian quadrature, and volume, and sets the corresponding values of
+        the respective tags for that tetrahedron.
         (Internal function not intended to be called externally)
 
         Arguments:

--- a/parastell/source_mesh.py
+++ b/parastell/source_mesh.py
@@ -5,8 +5,8 @@ import numpy as np
 from pymoab import core, types
 import pystell.read_vmec as read_vmec
 
-from . import log as log
-from .utils import read_yaml_config, filter_kwargs, m2cm, m3tocm3
+from . import log
+from .utils import ToroidalMesh, read_yaml_config, filter_kwargs, m2cm, m3tocm3
 
 export_allowed_kwargs = ["filename"]
 
@@ -61,10 +61,10 @@ def default_plasma_conditions(s):
     return n_i, T_i
 
 
-class SourceMesh(object):
+class SourceMesh(ToroidalMesh):
     """Generates a source mesh that describes the relative source intensity of
     neutrons in a magnetically confined plasma described by a VMEC plasma
-    equilibrium.
+    equilibrium. Inherits from ToroidalMesh.
 
     The mesh will be defined on a regular grid in the flux coordinates of
     (CFS value, poloidal angle, toroidal angle).  Mesh vertices will be defined
@@ -110,6 +110,7 @@ class SourceMesh(object):
     def __init__(
         self, vmec_obj, mesh_size, toroidal_extent, logger=None, **kwargs
     ):
+        super().__init__()
 
         self.logger = logger
         self.vmec_obj = vmec_obj
@@ -132,7 +133,7 @@ class SourceMesh(object):
         self.strengths = []
         self.volumes = []
 
-        self._create_mbc()
+        self._add_tags_to_core()
 
     @property
     def num_poloidal_pts(self):
@@ -192,12 +193,10 @@ class SourceMesh(object):
     def logger(self, logger_object):
         self._logger = log.check_init(logger_object)
 
-    def _create_mbc(self):
+    def _add_tags_to_core(self):
         """Creates PyMOAB core instance with source strength tag.
         (Internal function not intended to be called externally)
         """
-        self.mbc = core.Core()
-
         tag_type = types.MB_TYPE_DOUBLE
         tag_size = 1
         storage_type = types.MB_TAG_DENSE
@@ -282,18 +281,20 @@ class SourceMesh(object):
 
                     vert_idx += 1
 
-        self.verts = self.mbc.create_vertices(self.coords)
+        self.add_vertices(self.coords)
 
-    def _source_strength(self, tet_ids):
+    def _compute_tet_data(self, tet_ids, tet):
         """Computes neutron source strength for a tetrahedron using five-node
         Gaussian quadrature.
         (Internal function not intended to be called externally)
 
         Arguments:
-            ids (list of int): tetrahedron vertex indices.
+            tet_ids (list of int): tetrahedron vertex indices.
+            tet (object): pymoab.EntityHandle of tetrahedron.
 
         Returns:
             ss (float): integrated source strength for tetrahedron.
+            tet_vol (float): volume of tetrahedron
         """
         # Initialize list of vertex coordinates for each tetrahedron vertex
         tet_coords = [self.coords[id] for id in tet_ids]
@@ -328,27 +329,12 @@ class SourceMesh(object):
 
         ss = np.abs(tet_vol) * np.dot(int_w, ss_int_pts)
 
-        return ss, tet_vol
-
-    def _create_tet(self, tet_ids):
-        """Creates tetrahedron and adds to pyMOAB core.
-        (Internal function not intended to be called externally)
-
-        Arguments:
-            tet_ids (list of int): tetrahedron vertex indices.
-        """
-        tet_verts = [self.verts[int(id)] for id in tet_ids]
-        tet = self.mbc.create_element(types.MBTET, tet_verts)
-        self.mbc.add_entity(self.mesh_set, tet)
-
-        # Compute source strength for tetrahedron
-        ss, vol = self._source_strength(tet_ids)
         self.strengths.append(ss)
-        self.volumes.append(vol)
+        self.volumes.append(tet_vol)
 
         # Tag tetrahedra with data
         self.mbc.tag_set_data(self.source_strength_tag, tet, [ss])
-        self.mbc.tag_set_data(self.volume_tag, tet, [vol])
+        self.mbc.tag_set_data(self.volume_tag, tet, [tet_vol])
 
     def _get_vertex_id(self, vertex_idx):
         """Computes vertex index in row-major order as stored by MOAB from
@@ -362,7 +348,7 @@ class SourceMesh(object):
         Returns:
             id (int): vertex index in row-major order as stored by MOAB
         """
-        cfs_idx, poloidal_idx, toroidal_idx = vertex_idx
+        surface_idx, poloidal_idx, toroidal_idx = vertex_idx
 
         ma_offset = toroidal_idx * self.verts_per_plane
 
@@ -375,156 +361,45 @@ class SourceMesh(object):
 
         # Compute index offset from closed flux surface, taking single vertex
         # at magnetic axis into account
-        if cfs_idx == 0:
-            cfs_offset = cfs_idx
+        if surface_idx == 0:
+            surface_offset = surface_idx
         else:
-            cfs_offset = (cfs_idx - 1) * self.verts_per_ring + 1
+            surface_offset = (surface_idx - 1) * self.verts_per_ring + 1
 
         poloidal_offset = poloidal_idx
         # Wrap around if poloidal angle is 2*pi
         if poloidal_idx == self._num_poloidal_pts - 1:
             poloidal_offset = 0
 
-        id = ma_offset + cfs_offset + poloidal_offset
+        id = ma_offset + surface_offset + poloidal_offset
 
         return id
-
-    def _create_tets_from_hex(self, cfs_idx, poloidal_idx, toroidal_idx):
-        """Creates five tetrahedra from defined hexahedron.
-        (Internal function not intended to be called externally)
-
-        Arguments:
-            cfs_idx (int): index defining location along CFS axis.
-            poloidal_idx (int): index defining location along poloidal angle axis.
-            toroidal_idx (int): index defining location along toroidal angle axis.
-        """
-        # relative offsets of vertices in a 3-D index space
-        hex_vertex_stencil = np.array(
-            [
-                [0, 0, 0],
-                [1, 0, 0],
-                [1, 1, 0],
-                [0, 1, 0],
-                [0, 0, 1],
-                [1, 0, 1],
-                [1, 1, 1],
-                [0, 1, 1],
-            ]
-        )
-
-        # Ids of hex vertices applying offset stencil to current point
-        hex_idx_data = (
-            np.array([cfs_idx, poloidal_idx, toroidal_idx])
-            + hex_vertex_stencil
-        )
-
-        idx_list = [
-            self._get_vertex_id(vertex_idx) for vertex_idx in hex_idx_data
-        ]
-
-        # Define MOAB canonical ordering of hexahedron vertex indices
-        # Ordering follows right hand rule such that the fingers curl around
-        # one side of the tetrahedron and the thumb points to the remaining
-        # vertex. The vertices are ordered such that those on the side are
-        # first, ordered clockwise relative to the thumb, followed by the
-        # remaining vertex at the end of the thumb.
-        # See Moreno, Bader, Wilson 2024 for hexahedron splitting
-        canonical_ordering_schemes = [
-            [
-                [idx_list[0], idx_list[3], idx_list[1], idx_list[4]],
-                [idx_list[1], idx_list[3], idx_list[2], idx_list[6]],
-                [idx_list[1], idx_list[4], idx_list[6], idx_list[5]],
-                [idx_list[3], idx_list[6], idx_list[4], idx_list[7]],
-                [idx_list[1], idx_list[3], idx_list[6], idx_list[4]],
-            ],
-            [
-                [idx_list[0], idx_list[2], idx_list[1], idx_list[5]],
-                [idx_list[0], idx_list[3], idx_list[2], idx_list[7]],
-                [idx_list[0], idx_list[7], idx_list[5], idx_list[4]],
-                [idx_list[7], idx_list[2], idx_list[5], idx_list[6]],
-                [idx_list[0], idx_list[2], idx_list[5], idx_list[7]],
-            ],
-        ]
-
-        # Alternate canonical ordering schemes defining hexahedron splitting to
-        # avoid gaps and overlaps between non-planar hexahedron faces
-        scheme_idx = (cfs_idx + poloidal_idx + toroidal_idx) % 2
-
-        for vertex_ids in canonical_ordering_schemes[scheme_idx]:
-            self._create_tet(vertex_ids)
-
-    def _create_tets_from_wedge(self, poloidal_idx, toroidal_idx):
-        """Creates three tetrahedra from defined wedge.
-        (Internal function not intended to be called externally)
-
-        Arguments:
-            poloidal_idx (int): index defining location along poloidal angle axis.
-            toroidal_idx (int): index defining location along toroidal angle axis.
-        """
-        # relative offsets of wedge vertices in a 3-D index space
-        wedge_vertex_stencil = np.array(
-            [
-                [0, 0, 0],
-                [1, poloidal_idx, 0],
-                [1, poloidal_idx + 1, 0],
-                [0, 0, 1],
-                [1, poloidal_idx, 1],
-                [1, poloidal_idx + 1, 1],
-            ]
-        )
-
-        # Ids of wedge vertices applying offset stencil to current point
-        wedge_idx_data = np.array([0, 0, toroidal_idx]) + wedge_vertex_stencil
-
-        idx_list = [
-            self._get_vertex_id(vertex_idx) for vertex_idx in wedge_idx_data
-        ]
-
-        # Define MOAB canonical ordering of wedge vertex indices
-        # Ordering follows right hand rule such that the fingers curl around
-        # one side of the tetrahedron and the thumb points to the remaining
-        # vertex. The vertices are ordered such that those on the side are
-        # first, ordered clockwise relative to the thumb, followed by the
-        # remaining vertex at the end of the thumb.
-        # See Moreno, Bader, Wilson 2024 for wedge splitting
-        canonical_ordering_schemes = [
-            [
-                [idx_list[0], idx_list[2], idx_list[1], idx_list[3]],
-                [idx_list[1], idx_list[3], idx_list[5], idx_list[4]],
-                [idx_list[1], idx_list[3], idx_list[2], idx_list[5]],
-            ],
-            [
-                [idx_list[0], idx_list[2], idx_list[1], idx_list[3]],
-                [idx_list[3], idx_list[2], idx_list[4], idx_list[5]],
-                [idx_list[3], idx_list[2], idx_list[1], idx_list[4]],
-            ],
-        ]
-
-        # Alternate canonical ordering schemes defining wedge splitting to
-        # avoid gaps and overlaps between non-planar wedge faces
-        scheme_idx = (poloidal_idx + toroidal_idx) % 2
-
-        for vertex_ids in canonical_ordering_schemes[scheme_idx]:
-            self._create_tet(vertex_ids)
 
     def create_mesh(self):
         """Creates volumetric source mesh in real space."""
         self._logger.info("Constructing source mesh...")
 
-        self.mesh_set = self.mbc.create_meshset()
-        self.mbc.add_entity(self.mesh_set, self.verts)
-
         for toroidal_idx in range(self._num_toroidal_pts - 1):
             # Create tetrahedra for wedges at center of plasma
             for poloidal_idx in range(self._num_poloidal_pts - 1):
-                self._create_tets_from_wedge(poloidal_idx, toroidal_idx)
+                tets, vertex_id_list = self._create_tets_from_wedge(
+                    poloidal_idx, toroidal_idx
+                )
+                [
+                    self._compute_tet_data(tet_ids, tet)
+                    for tet_ids, tet in zip(vertex_id_list, tets)
+                ]
 
             # Create tetrahedra for hexahedra beyond center of plasma
             for cfs_idx in range(1, self.num_cfs_pts - 1):
                 for poloidal_idx in range(self._num_poloidal_pts - 1):
-                    self._create_tets_from_hex(
+                    tets, vertex_id_list = self._create_tets_from_hex(
                         cfs_idx, poloidal_idx, toroidal_idx
                     )
+                    [
+                        self._compute_tet_data(tet_ids, tet)
+                        for tet_ids, tet in zip(vertex_id_list, tets)
+                    ]
 
     def export_mesh(self, filename="source_mesh", export_dir=""):
         """Use PyMOAB interface to write source mesh with source strengths
@@ -538,8 +413,7 @@ class SourceMesh(object):
         """
         self._logger.info("Exporting source mesh H5M file...")
 
-        export_path = Path(export_dir) / Path(filename).with_suffix(".h5m")
-        self.mbc.write_file(str(export_path))
+        self.export(filename, export_dir=export_dir)
 
 
 def parse_args():

--- a/parastell/utils.py
+++ b/parastell/utils.py
@@ -645,7 +645,7 @@ class ToroidalMesh(ABC):
 
         return tets, vertex_id_list
 
-    def export(self, filename, export_dir=""):
+    def export_mesh(self, filename, export_dir=""):
         """Exports a tetrahedral mesh in H5M format via MOAB.
 
         Arguments:

--- a/parastell/utils.py
+++ b/parastell/utils.py
@@ -485,10 +485,24 @@ class ToroidalMesh(ABC):
     inheriting class has some method that iteratively calls
     "_create_tets_from_hex" and/or "_create_tets_from_wedge" to generate the
     mesh.
+
+    Arguments:
+        logger (object): logger object (defaults to None). If no logger is
+            supplied, a default logger will be instantiated.
     """
 
-    def __init__(self):
+    def __init__(self, logger=None):
+        self.logger = logger
+
         self.mbc = core.Core()
+
+    @property
+    def logger(self):
+        return self._logger
+
+    @logger.setter
+    def logger(self, logger_object):
+        self._logger = log.check_init(logger_object)
 
     def add_vertices(self, coords):
         """Creates vertices and adds to PyMOAB core.
@@ -653,5 +667,7 @@ class ToroidalMesh(ABC):
             export_dir (str): directory to which to export the h5m output file
                 (defaults to empty string).
         """
+        self._logger.info("Exporting mesh H5M file...")
+
         export_path = Path(export_dir) / Path(filename).with_suffix(".h5m")
         self.mbc.write_file(str(export_path))

--- a/tests/test_invessel_build.py
+++ b/tests/test_invessel_build.py
@@ -187,7 +187,8 @@ def test_ivb_exports(invessel_build):
     if check_cubit_installation():
         create_new_cubit_instance()
 
-        invessel_build.export_component_mesh(components=["component"])
+        invessel_build.mesh_components_cubit(components=["component"])
+        invessel_build.export_mesh_cubit("component")
         assert Path("component.h5m").exists()
 
     remove_files()

--- a/tests/test_invessel_build.py
+++ b/tests/test_invessel_build.py
@@ -176,6 +176,7 @@ def test_ivb_exports(invessel_build):
     imported.
     """
     remove_files()
+
     invessel_build.populate_surfaces()
     invessel_build.calculate_loci()
     invessel_build.generate_components()
@@ -190,5 +191,17 @@ def test_ivb_exports(invessel_build):
         invessel_build.mesh_components_cubit(components=["component"])
         invessel_build.export_mesh_cubit("component")
         assert Path("component.h5m").exists()
+
+    remove_files()
+
+    invessel_build.mesh_components_moab("component")
+    invessel_build.export_mesh_moab("component")
+    assert Path("component.h5m").exists()
+
+    remove_files()
+
+    invessel_build.mesh_components_gmsh(["component"])
+    invessel_build.export_mesh_gmsh("component")
+    assert Path("component.h5m").exists()
 
     remove_files()

--- a/tests/test_invessel_build.py
+++ b/tests/test_invessel_build.py
@@ -18,6 +18,7 @@ import pystell.read_vmec as read_vmec
 files_to_remove = [
     "chamber.step",
     "component.step",
+    "component.h5m",
     "stellarator.log",
 ]
 

--- a/tests/test_invessel_build.py
+++ b/tests/test_invessel_build.py
@@ -91,7 +91,7 @@ def test_ivb_basics(invessel_build):
     wall_s_exp = 1.08
     repeat_exp = 0
     num_ribs_exp = 11
-    num_rib_pts_exp = 67
+    num_rib_pts_exp = 61
     scale_exp = 100
     chamber_mat_tag_exp = "Vacuum"
 
@@ -194,7 +194,7 @@ def test_ivb_exports(invessel_build):
 
     remove_files()
 
-    invessel_build.mesh_components_moab("component")
+    invessel_build.mesh_component_moab("component")
     invessel_build.export_mesh_moab("component")
     assert Path("component.h5m").exists()
 

--- a/tests/test_magnet_coils.py
+++ b/tests/test_magnet_coils.py
@@ -225,6 +225,12 @@ def test_magnet_exports_from_filaments(coil_set_from_filaments):
         coil_set_from_filaments.export_mesh_cubit()
         assert Path("magnet_mesh.h5m").exists()
 
+        remove_files()
+
+    coil_set_from_filaments.mesh_magnets_gmsh()
+    coil_set_from_filaments.export_mesh_gmsh()
+    assert Path("magnet_mesh.h5m").exists()
+
     remove_files()
 
 
@@ -242,12 +248,19 @@ def test_magnet_exports_from_geometry(coil_set_from_geometry):
 
     volume_ids_exp = list(range(1, 2))
 
-    create_new_cubit_instance()
+    if check_cubit_installation():
+        create_new_cubit_instance()
 
-    coil_set_from_geometry.mesh_magnets_cubit()
-    assert coil_set_from_geometry.volume_ids == volume_ids_exp
+        coil_set_from_geometry.mesh_magnets_cubit()
+        assert coil_set_from_geometry.volume_ids == volume_ids_exp
 
-    coil_set_from_geometry.export_mesh_cubit()
+        coil_set_from_geometry.export_mesh_cubit()
+        assert Path("magnet_mesh.h5m").exists()
+
+        remove_files()
+
+    coil_set_from_geometry.mesh_magnets_gmsh()
+    coil_set_from_geometry.export_mesh_gmsh()
     assert Path("magnet_mesh.h5m").exists()
 
     remove_files()

--- a/tests/test_magnet_coils.py
+++ b/tests/test_magnet_coils.py
@@ -219,10 +219,10 @@ def test_magnet_exports_from_filaments(coil_set_from_filaments):
     if check_cubit_installation():
         create_new_cubit_instance()
 
-        coil_set_from_filaments.mesh_magnets()
+        coil_set_from_filaments.mesh_magnets_cubit()
         assert coil_set_from_filaments.volume_ids == volume_ids_exp
 
-        coil_set_from_filaments.export_mesh()
+        coil_set_from_filaments.export_mesh_cubit()
         assert Path("magnet_mesh.h5m").exists()
 
     remove_files()
@@ -244,10 +244,10 @@ def test_magnet_exports_from_geometry(coil_set_from_geometry):
 
     create_new_cubit_instance()
 
-    coil_set_from_geometry.mesh_magnets()
+    coil_set_from_geometry.mesh_magnets_cubit()
     assert coil_set_from_geometry.volume_ids == volume_ids_exp
 
-    coil_set_from_geometry.export_mesh()
+    coil_set_from_geometry.export_mesh_cubit()
     assert Path("magnet_mesh.h5m").exists()
 
     remove_files()

--- a/tests/test_parastell.py
+++ b/tests/test_parastell.py
@@ -88,7 +88,7 @@ def create_ivb_cad_magnets_from_filaments(stellarator_obj):
         stellarator_obj (object): parastell.Stellarator class object.
     """
     construct_invessel_build(stellarator_obj)
-    stellarator_obj.export_invessel_build()
+    stellarator_obj.export_invessel_build_step_step()
 
     coils_file = Path("files_for_tests") / "coils.example"
     width = 40.0
@@ -100,9 +100,9 @@ def create_ivb_cad_magnets_from_filaments(stellarator_obj):
         coils_file, width, thickness, toroidal_extent, sample_mod=sample_mod
     )
 
-    step_filename_exp = "magnet_set.step"
+    filename_exp = "magnet_set.step"
 
-    stellarator_obj.export_magnets(step_filename=step_filename_exp)
+    stellarator_obj.export_magnets_step(filename=filename_exp)
 
 
 def create_ivb_cad_magnets_from_cad(stellarator_obj):
@@ -113,7 +113,7 @@ def create_ivb_cad_magnets_from_cad(stellarator_obj):
         stellarator_obj (object): parastell.Stellarator class object.
     """
     construct_invessel_build(stellarator_obj)
-    stellarator_obj.export_invessel_build()
+    stellarator_obj.export_invessel_build_step()
 
     geometry_file = Path("files_for_tests") / "magnet_geom.step"
 
@@ -139,9 +139,9 @@ def create_ivb_pydagmc_magnets_from_filaments(stellarator_obj):
         coils_file, width, thickness, toroidal_extent, sample_mod=sample_mod
     )
 
-    step_filename_exp = "magnet_set.step"
+    filename_exp = "magnet_set.step"
 
-    stellarator_obj.export_magnets(step_filename=step_filename_exp)
+    stellarator_obj.export_magnets_step(filename=filename_exp)
 
 
 def create_ivb_pydagmc_magnets_from_cad(stellarator_obj):
@@ -180,7 +180,7 @@ def test_invessel_build(stellarator):
     chamber_filename_exp = Path("chamber").with_suffix(".step")
     component_filename_exp = Path(component_name_exp).with_suffix(".step")
 
-    stellarator.export_invessel_build()
+    stellarator.export_invessel_build_step()
 
     assert chamber_filename_exp.exists()
     assert component_filename_exp.exists()
@@ -210,14 +210,12 @@ def test_magnet_set(stellarator):
     export_mesh = check_cubit_installation()
     mesh_filename_exp = "magnet_mesh"
 
-    stellarator.export_magnets(
-        step_filename=step_filename_exp,
-        export_mesh=export_mesh,
-        mesh_filename=mesh_filename_exp,
-    )
+    stellarator.export_magnets_step(filename=step_filename_exp)
 
     assert Path(step_filename_exp).with_suffix(".step").exists()
+
     if export_mesh:
+        stellarator.export_magnet_mesh_cubit(filename=mesh_filename_exp)
         assert Path(mesh_filename_exp).with_suffix(".h5m").exists()
 
     remove_files()

--- a/tests/test_parastell.py
+++ b/tests/test_parastell.py
@@ -88,7 +88,7 @@ def create_ivb_cad_magnets_from_filaments(stellarator_obj):
         stellarator_obj (object): parastell.Stellarator class object.
     """
     construct_invessel_build(stellarator_obj)
-    stellarator_obj.export_invessel_build_step_step()
+    stellarator_obj.export_invessel_build_step()
 
     coils_file = Path("files_for_tests") / "coils.example"
     width = 40.0
@@ -174,16 +174,28 @@ def test_invessel_build(stellarator):
     """
     remove_files()
 
-    component_name_exp = "component"
     construct_invessel_build(stellarator)
 
-    chamber_filename_exp = Path("chamber").with_suffix(".step")
-    component_filename_exp = Path(component_name_exp).with_suffix(".step")
+    chamber_step_filename_exp = Path("chamber").with_suffix(".step")
+    component_step_filename_exp = Path("component").with_suffix(".step")
+    component_h5m_filename_exp = Path("component").with_suffix(".h5m")
 
     stellarator.export_invessel_build_step()
+    stellarator.export_invessel_build_mesh_cubit("component", ["components"])
 
-    assert chamber_filename_exp.exists()
-    assert component_filename_exp.exists()
+    assert chamber_step_filename_exp.exists()
+    assert component_step_filename_exp.exists()
+    assert component_h5m_filename_exp.exists()
+
+    remove_files()
+
+    stellarator.export_invessel_build_mesh_moab("component", "component")
+    assert component_h5m_filename_exp.exists()
+
+    remove_files()
+
+    stellarator.export_invessel_build_mesh_gmsh("component", ["components"])
+    assert component_h5m_filename_exp.exists()
 
     remove_files()
 

--- a/tests/test_parastell.py
+++ b/tests/test_parastell.py
@@ -13,6 +13,7 @@ from parastell.cubit_utils import (
 files_to_remove = [
     "chamber.step",
     "component.step",
+    "component.h5m",
     "magnet_set.step",
     "magnet_mesh.exo",
     "magnet_mesh.h5m",
@@ -219,16 +220,19 @@ def test_magnet_set(stellarator):
     )
 
     step_filename_exp = "magnet_set.step"
-    export_mesh = check_cubit_installation()
-    mesh_filename_exp = "magnet_mesh"
 
     stellarator.export_magnets_step(filename=step_filename_exp)
 
     assert Path(step_filename_exp).with_suffix(".step").exists()
 
-    if export_mesh:
-        stellarator.export_magnet_mesh_cubit(filename=mesh_filename_exp)
-        assert Path(mesh_filename_exp).with_suffix(".h5m").exists()
+    if check_cubit_installation():
+        stellarator.export_magnet_mesh_cubit()
+        assert Path("magnet_mesh").with_suffix(".h5m").exists()
+
+        remove_files()
+
+    stellarator.export_magnet_mesh_gmsh()
+    assert Path("magnet_mesh").with_suffix(".h5m").exists()
 
     remove_files()
 

--- a/tests/test_parastell.py
+++ b/tests/test_parastell.py
@@ -181,7 +181,7 @@ def test_invessel_build(stellarator):
     component_h5m_filename_exp = Path("component").with_suffix(".h5m")
 
     stellarator.export_invessel_build_step()
-    stellarator.export_invessel_build_mesh_cubit("component", ["components"])
+    stellarator.export_invessel_build_mesh_cubit("component", ["component"])
 
     assert chamber_step_filename_exp.exists()
     assert component_step_filename_exp.exists()
@@ -194,7 +194,7 @@ def test_invessel_build(stellarator):
 
     remove_files()
 
-    stellarator.export_invessel_build_mesh_gmsh("component", ["components"])
+    stellarator.export_invessel_build_mesh_gmsh("component", ["component"])
     assert component_h5m_filename_exp.exists()
 
     remove_files()

--- a/tests/test_parastell.py
+++ b/tests/test_parastell.py
@@ -182,20 +182,25 @@ def test_invessel_build(stellarator):
     component_h5m_filename_exp = Path("component").with_suffix(".h5m")
 
     stellarator.export_invessel_build_step()
-    stellarator.export_invessel_build_mesh_cubit("component", ["component"])
 
     assert chamber_step_filename_exp.exists()
     assert component_step_filename_exp.exists()
-    assert component_h5m_filename_exp.exists()
 
-    remove_files()
+    if check_cubit_installation():
+        stellarator.export_invessel_build_mesh_cubit(
+            ["component"], "component"
+        )
+
+        assert component_h5m_filename_exp.exists()
+
+        remove_files()
 
     stellarator.export_invessel_build_mesh_moab("component", "component")
     assert component_h5m_filename_exp.exists()
 
     remove_files()
 
-    stellarator.export_invessel_build_mesh_gmsh("component", ["component"])
+    stellarator.export_invessel_build_mesh_gmsh(["component"], "component")
     assert component_h5m_filename_exp.exists()
 
     remove_files()

--- a/tests/test_source_mesh.py
+++ b/tests/test_source_mesh.py
@@ -117,12 +117,14 @@ def test_export(source_mesh):
     testing if:
         * the expected H5M file is produced
     """
+    filename_exp = "source_mesh.h5m"
+
     remove_files()
 
     source_mesh.create_vertices()
     source_mesh.create_mesh()
-    source_mesh.export_mesh()
+    source_mesh.export_mesh(filename_exp)
 
-    assert Path("source_mesh.h5m").exists()
+    assert Path(filename_exp).exists()
 
     remove_files()


### PR DESCRIPTION
This branch introduces open-source tetrahedral meshing workflows for the `InVesselBuild` and `MagnetSet` classes.

The `InVesselBuild` class has two meshing routines added, one using MOAB and another using Gmsh.

- The MOAB routine, analogous to the PyDAGMC workflow, uses the IVB point cloud to generate a mesh in MOAB for a single specified component. In the resulting mesh, the component is one tetrahedron thick. In fact, one purpose of this MOAB workflow is to ensure a one-tetrahedron-thick mesh (useful for mesh tallies). This capability may be expanded to include multiple components in a single mesh.
- The Gmsh routine is usable with both CadQuery and PyDAGMC geometries. When used in conjunction with CadQuery geometries, CadQuery CAD solids are directly imported and meshed. When used with PyDAGMC geometries, PyDAGMC volumes are imported and remeshed according to specified parameters.

The `MagnetSet` class has one meshing routine added, using Gmsh. Like the `InVesselBuild` Gmsh routine, this routine directly imports CadQuery CAD solids and meshes those.

List of changes:

- Adds MOAB and Gmsh meshing routines for the `InVesselBuild` class
- Adds Gmsh meshing routine for the `MagnetSet` class
- Adds tests to cover new functionality
- Standardizes Cubit meshing methods across ParaStell classes
- Standardizes export method naming convention
- Updates tests and examples to reflect changes in API
- Introduces `ToroidalMesh` abstract base class

Closes #140 