### PR TITLE
update to import pydagmc

### DIFF
--- a/parastell/invessel_build.py
+++ b/parastell/invessel_build.py
@@ -6,7 +6,7 @@ from scipy.interpolate import RegularGridInterpolator
 
 import cadquery as cq
 import pystell.read_vmec as read_vmec
-import dagmc
+import pydagmc
 from pymoab import core, types
 
 from . import log
@@ -151,7 +151,7 @@ class InVesselBuild(object):
         self._use_pydagmc = value
         if self._use_pydagmc:
             self.mbc = core.Core()
-            self.dag_model = dagmc.DAGModel(self.mbc)
+            self.dag_model = pydagmc.DAGModel(self.mbc)
 
     def _interpolate_offset_matrix(self, offset_mat):
         """Interpolates total offset for expanded angle lists using cubic spline
@@ -404,7 +404,7 @@ class InVesselBuild(object):
         ):
 
             mat = layer_data.get("mat_tag", layer_name)
-            group = dagmc.Group.create(self.dag_model, name="mat:" + mat)
+            group = pydagmc.Group.create(self.dag_model, name="mat:" + mat)
             group.add_set(vol)
             layer_data["vol_id"] = vol.id
 

--- a/parastell/utils.py
+++ b/parastell/utils.py
@@ -8,7 +8,7 @@ import numpy as np
 import math
 from scipy.ndimage import gaussian_filter
 from pymoab import core, types
-import dagmc
+import pydagmc
 import cadquery as cq
 from OCP.BRepBuilderAPI import BRepBuilderAPI_Sewing
 from OCP.StlAPI import StlAPI_Reader
@@ -317,7 +317,7 @@ def combine_dagmc_models(models_to_merge):
             model.write_file(temp_filename)
             renumberizer.load_file(temp_filename)
     renumberizer.renumber_ids()
-    return dagmc.DAGModel(renumberizer.mb)
+    return pydagmc.DAGModel(renumberizer.mb)
 
 
 def stl_to_cq_solid(stl_path, tolerance=0.001):

--- a/tests/test_parastell.py
+++ b/tests/test_parastell.py
@@ -2,7 +2,7 @@ from pathlib import Path
 
 import numpy as np
 import pytest
-import dagmc
+import pydagmc
 
 import parastell.parastell as ps
 from parastell.cubit_utils import (
@@ -41,7 +41,7 @@ def check_surfaces_and_volumes(filename, num_surfaces_exp, num_volumes_exp):
         num_surfaces_exp (int): expected number of surfaces.
         num_volumes_exp (int): expected number of volumes.
     """
-    dagmc_model = dagmc.DAGModel(str(Path(filename).with_suffix(".h5m")))
+    dagmc_model = pydagmc.DAGModel(str(Path(filename).with_suffix(".h5m")))
 
     assert len(dagmc_model.surfaces) == num_surfaces_exp
     assert len(dagmc_model.volumes) == num_volumes_exp

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -94,7 +94,7 @@ def test_stl_surfaces_to_cq_solid():
         solid (using math.isclose()).
     """
     vol_id = 1
-    dagmc_model = dagmc.DAGModel("files_for_tests/one_cube.h5m")
+    dagmc_model = pydagmc.DAGModel("files_for_tests/one_cube.h5m")
     volume = dagmc_model.volumes_by_id[vol_id]
     dagmc_volume_volume = volume.volume
 


### PR DESCRIPTION
Updates to use the new import name for pydagmc.
Closes #211
Tests should be failing currently, when https://github.com/svalinn/pydagmc/pull/31 gets merged, we should be able to update the CI image and see that tests will be passing. 