### PR TITLE
Make manually triggered workflow use no cache

### DIFF
--- a/.github/workflows/docker_publish.yml
+++ b/.github/workflows/docker_publish.yml
@@ -42,9 +42,6 @@ jobs:
         run: |
           echo "EXTRA_TAG=-${{ github.ref_name }}" >> $GITHUB_ENV
           echo "EXTRA_TAG_CI=:${{ github.ref_name }}" >> $GITHUB_ENV
-      - name: Set cache option if workflow was manually triggered
-        if: github.event_name == 'workflow_dispatch'
-        run: echo "NO_CACHE=${{ github.event.inputs.no_cache }}" >> $GITHUB_ENV
       - id: output_tag
         run: echo "image_tag=$EXTRA_TAG_CI" >> $GITHUB_OUTPUT
       - name: Build and push ParaStell Docker image (with cache)

--- a/.github/workflows/docker_publish.yml
+++ b/.github/workflows/docker_publish.yml
@@ -12,6 +12,7 @@ on:
 env:
   EXTRA_TAG: ""
   EXTRA_TAG_CI: ""
+  USE_CACHE: "true"
 
 jobs:
   build-dependency-img:
@@ -41,16 +42,30 @@ jobs:
         run: |
           echo "EXTRA_TAG=-${{ github.ref_name }}" >> $GITHUB_ENV
           echo "EXTRA_TAG_CI=:${{ github.ref_name }}" >> $GITHUB_ENV
-
+      - name: Disable cache if workflow was manually triggered
+        if: github.event_name == 'workflow_dispatch'
+        run: echo "USE_CACHE=false" >> $GITHUB_ENV
       - id: output_tag
         run: echo "image_tag=$EXTRA_TAG_CI" >> $GITHUB_OUTPUT
 
-      - name: Build and push ParaStell Docker image
-        id: build-parastell
+      - name: Build and push ParaStell Docker image (with cache)
+        id: build-parastell-with-cache
+        if: env.USE_CACHE == 'true'
         uses: docker/build-push-action@v5
         with:
           cache-from: type=registry,ref=ghcr.io/svalinn/parastell:ci-layer-cache${{ env.EXTRA_TAG }}
           cache-to: type=registry,ref=ghcr.io/svalinn/parastell:ci-layer-cache${{ env.EXTRA_TAG }},mode=max
+          file: Dockerfile
+          push: true
+          target: parastell-deps
+          tags: ghcr.io/svalinn/parastell-ci${{ env.EXTRA_TAG_CI }}
+          
+      - name: Build and push ParaStell Docker image (no cache)
+        id: build-parastell-no-cache
+        if: env.USE_CACHE == 'false'
+        uses: docker/build-push-action@v5
+        with:
+          no-cache: true
           file: Dockerfile
           push: true
           target: parastell-deps

--- a/.github/workflows/docker_publish.yml
+++ b/.github/workflows/docker_publish.yml
@@ -19,7 +19,7 @@ on:
 env:
   EXTRA_TAG: ""
   EXTRA_TAG_CI: ""
-  USE_CACHE: "true"
+  NO_CACHE: "false"
 jobs:
   build-dependency-img:
     runs-on: ubuntu-latest

--- a/.github/workflows/docker_publish.yml
+++ b/.github/workflows/docker_publish.yml
@@ -6,7 +6,7 @@ on:
       use_cache:
         description: "Use Cache for Build"
         required: true
-        default: 'false'
+        default: 'true'
         type: choice
         options:
           - 'true'

--- a/.github/workflows/docker_publish.yml
+++ b/.github/workflows/docker_publish.yml
@@ -1,53 +1,52 @@
 name: Build & publish Docker image for ParaStell CI
-
 on:
   # allows us to run workflows manually
   workflow_dispatch:
+    inputs:
+      use_cache:
+        description: 'Use cache for build'
+        required: true
+        default: 'true'
+        type: choice
+        options:
+          - 'true'
+          - 'false'
   push:
     paths:
       - 'Dockerfile'
       - '.github/workflows/docker_publish.yml'
       - 'environment.yml'
-
 env:
   EXTRA_TAG: ""
   EXTRA_TAG_CI: ""
   USE_CACHE: "true"
-
 jobs:
   build-dependency-img:
     runs-on: ubuntu-latest
-
     name: Install Dependencies
-
     outputs: 
       image_tag: ${{ steps.output_tag.outputs.image_tag }}
-
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
-
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
-
       - name: Log into GitHub Container Registry
         uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
-
       - name: Add extra tag if NOT on the main branch
         if: github.ref_name != 'main'
         run: |
           echo "EXTRA_TAG=-${{ github.ref_name }}" >> $GITHUB_ENV
           echo "EXTRA_TAG_CI=:${{ github.ref_name }}" >> $GITHUB_ENV
-      - name: Disable cache if workflow was manually triggered
+      - name: Set cache option if workflow was manually triggered
         if: github.event_name == 'workflow_dispatch'
-        run: echo "USE_CACHE=false" >> $GITHUB_ENV
+        run: echo "USE_CACHE=${{ github.event.inputs.use_cache }}" >> $GITHUB_ENV
       - id: output_tag
         run: echo "image_tag=$EXTRA_TAG_CI" >> $GITHUB_OUTPUT
-
       - name: Build and push ParaStell Docker image (with cache)
         id: build-parastell-with-cache
         if: env.USE_CACHE == 'true'

--- a/.github/workflows/docker_publish.yml
+++ b/.github/workflows/docker_publish.yml
@@ -3,8 +3,8 @@ on:
   # allows us to run workflows manually
   workflow_dispatch:
     inputs:
-      no_cache:
-        description: "Don't Use Cache for Build"
+      use_cache:
+        description: "Use Cache for Build"
         required: true
         default: 'false'
         type: choice
@@ -48,7 +48,7 @@ jobs:
         id: build-parastell
         uses: docker/build-push-action@v5
         with:
-          no-cache: ${{ github.event.inputs.no_cache == 'true' }}
+          no-cache: ${{ github.event.inputs.use_cache == 'false' }}
           cache-from: type=registry,ref=ghcr.io/svalinn/parastell:ci-layer-cache${{ env.EXTRA_TAG }}
           cache-to: type=registry,ref=ghcr.io/svalinn/parastell:ci-layer-cache${{ env.EXTRA_TAG }},mode=max
           file: Dockerfile

--- a/.github/workflows/docker_publish.yml
+++ b/.github/workflows/docker_publish.yml
@@ -44,8 +44,8 @@ jobs:
           echo "EXTRA_TAG_CI=:${{ github.ref_name }}" >> $GITHUB_ENV
       - id: output_tag
         run: echo "image_tag=$EXTRA_TAG_CI" >> $GITHUB_OUTPUT
-      - name: Build and push ParaStell Docker image (with cache)
-        id: build-parastell-with-cache
+      - name: Build and push ParaStell Docker image
+        id: build-parastell
         uses: docker/build-push-action@v5
         with:
           no-cache: ${{ github.event.inputs.no_cache == 'true' }}

--- a/.github/workflows/docker_publish.yml
+++ b/.github/workflows/docker_publish.yml
@@ -3,10 +3,10 @@ on:
   # allows us to run workflows manually
   workflow_dispatch:
     inputs:
-      use_cache:
-        description: 'Use cache for build'
+      no_cache:
+        description: "Don't Use Cache for Build"
         required: true
-        default: 'true'
+        default: 'false'
         type: choice
         options:
           - 'true'
@@ -44,27 +44,16 @@ jobs:
           echo "EXTRA_TAG_CI=:${{ github.ref_name }}" >> $GITHUB_ENV
       - name: Set cache option if workflow was manually triggered
         if: github.event_name == 'workflow_dispatch'
-        run: echo "USE_CACHE=${{ github.event.inputs.use_cache }}" >> $GITHUB_ENV
+        run: echo "NO_CACHE=${{ github.event.inputs.no_cache }}" >> $GITHUB_ENV
       - id: output_tag
         run: echo "image_tag=$EXTRA_TAG_CI" >> $GITHUB_OUTPUT
       - name: Build and push ParaStell Docker image (with cache)
         id: build-parastell-with-cache
-        if: env.USE_CACHE == 'true'
         uses: docker/build-push-action@v5
         with:
+          no-cache: env.NO_CACHE
           cache-from: type=registry,ref=ghcr.io/svalinn/parastell:ci-layer-cache${{ env.EXTRA_TAG }}
           cache-to: type=registry,ref=ghcr.io/svalinn/parastell:ci-layer-cache${{ env.EXTRA_TAG }},mode=max
-          file: Dockerfile
-          push: true
-          target: parastell-deps
-          tags: ghcr.io/svalinn/parastell-ci${{ env.EXTRA_TAG_CI }}
-          
-      - name: Build and push ParaStell Docker image (no cache)
-        id: build-parastell-no-cache
-        if: env.USE_CACHE == 'false'
-        uses: docker/build-push-action@v5
-        with:
-          no-cache: true
           file: Dockerfile
           push: true
           target: parastell-deps

--- a/.github/workflows/docker_publish.yml
+++ b/.github/workflows/docker_publish.yml
@@ -19,7 +19,7 @@ on:
 env:
   EXTRA_TAG: ""
   EXTRA_TAG_CI: ""
-  NO_CACHE: "false"
+
 jobs:
   build-dependency-img:
     runs-on: ubuntu-latest
@@ -51,7 +51,7 @@ jobs:
         id: build-parastell-with-cache
         uses: docker/build-push-action@v5
         with:
-          no-cache: env.NO_CACHE
+          no-cache: ${{ github.event.inputs.no_cache == 'true' }}
           cache-from: type=registry,ref=ghcr.io/svalinn/parastell:ci-layer-cache${{ env.EXTRA_TAG }}
           cache-to: type=registry,ref=ghcr.io/svalinn/parastell:ci-layer-cache${{ env.EXTRA_TAG }},mode=max
           file: Dockerfile


### PR DESCRIPTION
Since the PyDAGMC change did not affect any of the inputs to the docker image, I believe that the cached version was used when I manually triggered the CI image to build.

If I did everything right, this PR should make it so the CI image will be built with no cache when the workflow is triggered manually. This will take a bit longer for manual runs, but will ensure that we get a build with all the latest quirks and features when triggering manually.