### PR TITLE
Update syntax for newer versions of CAD-to-DAGMC

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -8,7 +8,7 @@ dependencies:
   - scipy
   - cadquery
   - moab=5.5.1[build=nompi_tempest_*]
-  - cad_to_dagmc=0.8.2
+  - cad_to_dagmc >=0.9.1
   - ca-certificates
   - certifi
   - openssl

--- a/parastell/parastell.py
+++ b/parastell/parastell.py
@@ -590,9 +590,11 @@ class Stellarator(object):
             gmsh_obj, self._geometry, method="in memory"
         )
 
-        cad_to_dagmc.mesh_brep(
+        cad_to_dagmc.set_sizes_for_mesh(
             gmsh_obj, min_mesh_size=min_mesh_size, max_mesh_size=max_mesh_size
         )
+
+        gmsh_obj.model.mesh.generate(dim=2)
 
         vertices, triangles_by_solid_and_by_face = (
             cad_to_dagmc.mesh_to_vertices_and_triangles(volumes)


### PR DESCRIPTION
Updates use of CAD-to-DAGMC's API for versions 0.9.1+ and pins those versions in the conda environment file.

Closes #227 