### PR TITLE
Add support for continuous, 360-degree geometries in PyDAGMC workflow

### DIFF
--- a/parastell/invessel_build.py
+++ b/parastell/invessel_build.py
@@ -542,7 +542,7 @@ class InVesselBuild(object):
             mb_tris = []
 
             if continuous_geom:
-                ribs = surface.Ribs[:-1].append(surface.Ribs[0])
+                ribs = surface.Ribs[:-1] + [surface.Ribs[0]]
             else:
                 ribs = surface.Ribs
 
@@ -656,12 +656,14 @@ class InVesselBuild(object):
             == 360.0
         ):
             continuous_geom = True
+        else:
+            continuous_geom = False
 
         self._generate_pymoab_verts()
         self._generate_curved_surfaces_pydagmc(continuous_geom=continuous_geom)
         if not continuous_geom:
             self._generate_end_cap_surfaces_pydagmc()
-        self._generate_volumes_pydagmc()
+        self._generate_volumes_pydagmc(continuous_geom=continuous_geom)
         self._tag_volumes_with_materials_pydagmc()
 
     def get_loci(self):

--- a/parastell/invessel_build.py
+++ b/parastell/invessel_build.py
@@ -532,7 +532,15 @@ class InVesselBuild(object):
         first_surface = surfaces[0]
         for surface in surfaces:
             mb_tris = []
-            for rib, next_rib in zip(surface.Ribs[0:-1], surface.Ribs[1:]):
+            if (
+                self.radial_build.toroidal_angles[-1]
+                - self.radial_build.toroidal_angles[0]
+                == 2 * np.pi
+            ):
+                ribs = surface.Ribs[:-1].append(surface.ribs[0])
+            else:
+                ribs = surface.Ribs
+            for rib, next_rib in zip(ribs[0:-1], ribs[1:]):
                 mb_tris += self._connect_ribs_with_tris_moab(
                     rib,
                     next_rib,
@@ -638,7 +646,12 @@ class InVesselBuild(object):
         )
         self._generate_pymoab_verts()
         self._generate_curved_surfaces_pydagmc()
-        self._generate_end_cap_surfaces_pydagmc()
+        if (
+            self.radial_build.toroidal_angles[-1]
+            - self.radial_build.toroidal_angles[0]
+            < 2 * np.pi
+        ):
+            self._generate_end_cap_surfaces_pydagmc()
         self._generate_volumes_pydagmc()
         self._tag_volumes_with_materials_pydagmc()
 

--- a/parastell/invessel_build.py
+++ b/parastell/invessel_build.py
@@ -523,7 +523,7 @@ class InVesselBuild(object):
             for surface in self.Surfaces.values()
         ]
 
-    def _generate_curved_surfaces_pydagmc(self, continuous_geom=False):
+    def _generate_curved_surfaces_pydagmc(self, continuous_360=False):
         """Generate the faceted representation of each curved surface and
         add it to the PyDAGMC model, remembering the surface ids. The sense
         of the triangles should point outward (increasing radial direction),
@@ -532,7 +532,7 @@ class InVesselBuild(object):
         (Internal function not intended to be called externally)
 
         Arguments:
-            continuous_geom (bool): flag indicating whether 360-degree,
+            continuous_360 (bool): flag indicating whether 360-degree,
                 continuous geometries should be generated.
         """
         self.curved_surface_ids = []
@@ -541,7 +541,7 @@ class InVesselBuild(object):
         for surface in surfaces:
             mb_tris = []
 
-            if continuous_geom:
+            if continuous_360:
                 ribs = surface.Ribs[:-1] + [surface.Ribs[0]]
             else:
                 ribs = surface.Ribs
@@ -580,7 +580,7 @@ class InVesselBuild(object):
 
             self.end_cap_surface_ids.append(end_cap_pair)
 
-    def _generate_volumes_pydagmc(self, continuous_geom=False):
+    def _generate_volumes_pydagmc(self, continuous_360=False):
         """Use the curved surface and end cap surface IDs to build the
         the volumes by applying the correct surface sense to each surface.
         The convention here is to point the surface sense toward the implicit
@@ -589,7 +589,7 @@ class InVesselBuild(object):
         (Internal function not intended to be called externally)
 
         Arguments:
-            continuous_geom (bool): flag indicating whether 360-degree,
+            continuous_360 (bool): flag indicating whether 360-degree,
                 continuous geometries should be generated.
         """
 
@@ -620,7 +620,7 @@ class InVesselBuild(object):
         ]
 
         # all end caps go to the implicit complement.
-        if not continuous_geom:
+        if not continuous_360:
             for vol_id, end_cap_ids in enumerate(
                 self.end_cap_surface_ids, start=1
             ):
@@ -650,20 +650,20 @@ class InVesselBuild(object):
             "Generating DAGMC model of in-vessel components with PyDAGMC..."
         )
 
-        if (
+        if np.isclose(
             self.radial_build.toroidal_angles[-1]
-            - self.radial_build.toroidal_angles[0]
-            == 360.0
+            - self.radial_build.toroidal_angles[0],
+            360.0,
         ):
-            continuous_geom = True
+            continuous_360 = True
         else:
-            continuous_geom = False
+            continuous_360 = False
 
         self._generate_pymoab_verts()
-        self._generate_curved_surfaces_pydagmc(continuous_geom=continuous_geom)
-        if not continuous_geom:
+        self._generate_curved_surfaces_pydagmc(continuous_360=continuous_360)
+        if not continuous_360:
             self._generate_end_cap_surfaces_pydagmc()
-        self._generate_volumes_pydagmc(continuous_geom=continuous_geom)
+        self._generate_volumes_pydagmc(continuous_360=continuous_360)
         self._tag_volumes_with_materials_pydagmc()
 
     def get_loci(self):

--- a/tests/test_parastell.py
+++ b/tests/test_parastell.py
@@ -81,6 +81,40 @@ def construct_invessel_build(stellarator_obj, use_pydagmc=False):
     )
 
 
+def construct_invessel_build_360(stellarator_obj):
+    """Constructs the in-vessel build of a Stellarator class object using a
+    360-degree, continuous geometry.
+
+    Arguments:
+        stellarator_obj (object): parastell.Stellarator class object.
+        use_pydagmc (bool): flag to indicate whether ParaStell's PyDAGMC
+            workflow should be used to construct the in-vessel build (defaults
+            to False).
+    """
+    toroidal_angles = [0.0, 120.0, 240.0, 360.0]
+    poloidal_angles = [0.0, 120.0, 240.0, 360.0]
+    wall_s = 1.08
+    component_name = "component"
+    radial_build_dict = {
+        component_name: {
+            "thickness_matrix": np.ones(
+                (len(toroidal_angles), len(poloidal_angles))
+            )
+            * 10
+        }
+    }
+    num_ribs = 241
+
+    stellarator_obj.construct_invessel_build(
+        toroidal_angles,
+        poloidal_angles,
+        wall_s,
+        radial_build_dict,
+        num_ribs=num_ribs,
+        use_pydagmc=True,
+    )
+
+
 def create_ivb_cad_magnets_from_filaments(stellarator_obj):
     """Constructs the in-vessel build (CadQuery workflow) and magnet set (from
     filaments) of a Stellarator class object.
@@ -134,6 +168,31 @@ def create_ivb_pydagmc_magnets_from_filaments(stellarator_obj):
     width = 40.0
     thickness = 50.0
     toroidal_extent = 90.0
+    sample_mod = 6
+
+    stellarator_obj.construct_magnets_from_filaments(
+        coils_file, width, thickness, toroidal_extent, sample_mod=sample_mod
+    )
+
+    filename_exp = "magnet_set.step"
+
+    stellarator_obj.export_magnets_step(filename=filename_exp)
+
+
+def create_ivb_pydagmc_magnets_from_filaments_360(stellarator_obj):
+    """Constructs the in-vessel build (PyDAGMC workflow) and magnet set (from
+    filaments) of a Stellarator class object using a 360-degree, continuous
+    geometry.
+
+    Arguments:
+        stellarator_obj (object): parastell.Stellarator class object.
+    """
+    construct_invessel_build_360(stellarator_obj)
+
+    coils_file = Path("files_for_tests") / "coils.example"
+    width = 40.0
+    thickness = 50.0
+    toroidal_extent = 360.0
     sample_mod = 6
 
     stellarator_obj.construct_magnets_from_filaments(
@@ -488,6 +547,75 @@ def test_pydagmc_ps_geom_cad_to_dagmc(stellarator):
 
     # One magnet and one component
     num_volumes_exp = 2
+
+    check_surfaces_and_volumes("dagmc.h5m", num_surfaces_exp, num_volumes_exp)
+
+    remove_files()
+
+
+def test_pydagmc_ps_geom_cubit_360(stellarator):
+    """Tests whether the PyDAGMC workflow produces the expected 360-degree,
+    continuous model, using constructed magnets faceted via Cubit, by testing
+    if:
+        * the expected H5M file is produced
+        * the correct number of surfaces and volumes are assembled
+
+    This test is skipped if Cubit cannot be imported.
+    """
+    pytest.importorskip("cubit")
+
+    remove_files()
+    create_new_cubit_instance()
+
+    create_ivb_pydagmc_magnets_from_filaments_360(stellarator)
+
+    # Intentionally pass a kwarg for 'cad_to_dagmc' export to verify that
+    # kwargs are filtered appropriately
+    stellarator.build_pydagmc_model(
+        magnet_exporter="cubit", deviation_angle=6, max_mesh_size=40
+    )
+    stellarator.export_pydagmc_model("dagmc.h5m")
+
+    assert Path("dagmc.h5m").exists()
+
+    # No plasma chamber. 8 surfaces from two magnets, 2 surfaces from single
+    # component.
+    num_surfaces_exp = 10
+
+    # Two magnets and one component
+    num_volumes_exp = 3
+
+    check_surfaces_and_volumes("dagmc.h5m", num_surfaces_exp, num_volumes_exp)
+
+    remove_files()
+
+
+def test_pydagmc_ps_geom_cad_to_dagmc_360(stellarator):
+    """Tests whether the PyDAGMC workflow produces the expected 360-degree,
+    continuous model, using constructed magnets faceted via CAD-to-DAGMC, by
+    testing if:
+        * the expected H5M file is produced
+        * the correct number of surfaces and volumes are assembled
+    """
+    remove_files()
+
+    create_ivb_pydagmc_magnets_from_filaments_360(stellarator)
+
+    # Intentionally pass a kwarg for 'cubit' export to verify that
+    # kwargs are filtered appropriately
+    stellarator.build_pydagmc_model(
+        magnet_exporter="cad_to_dagmc", deviation_angle=6, max_mesh_size=40
+    )
+    stellarator.export_pydagmc_model("dagmc.h5m")
+
+    assert Path("dagmc.h5m").exists()
+
+    # No plasma chamber. 8 surfaces from two magnets, 2 surfaces from single
+    # component.
+    num_surfaces_exp = 10
+
+    # Two magnets and one component
+    num_volumes_exp = 3
 
     check_surfaces_and_volumes("dagmc.h5m", num_surfaces_exp, num_volumes_exp)
 


### PR DESCRIPTION
Adds support for modeling continuous, 360-degree geometries for the PyDAGMC workflow (note that continuous geometries were already supported in the CAD-based workflow using the `repeat` parameter). Also adds a test to `test_parastell.py` to check this functionality.