### PR TITLE
Add support for multi-component IVB meshes using the MOAB workflow

### DIFF
--- a/parastell/invessel_build.py
+++ b/parastell/invessel_build.py
@@ -772,10 +772,11 @@ class InVesselBuild(object):
         for component_idx, component in enumerate(components):
             # Extract inner and outer surfaces of current component
             outer_surface = self.Surfaces[component]
-            # Inner surface of current component is outer surface of the previous
-            # component. Since surfaces are created in order of components and
-            # named after the component for which they are the outer surface,
-            # it can be found by the ordered list of surface keys
+            # Inner surface of current component is outer surface of the
+            # previous component. Since surfaces are created in order of
+            # components and named after the component for which they are the
+            # outer surface, it can be found by the ordered list of surface
+            # keys
             inner_surf_idx = surface_keys.index(component) - 1
             inner_component = surface_keys[inner_surf_idx]
             inner_surface = self.Surfaces[inner_component]
@@ -786,9 +787,8 @@ class InVesselBuild(object):
             # If the inner component is not the previous component specified to
             # be meshed, identify a gap and add the inner surface
             elif surfaces[-1] != inner_surface:
-                print(surfaces[-1], inner_surface)
                 surfaces.append(inner_surface)
-                # don't mesh the gap between this surface and its predecessor
+                # Don't mesh the gap between this surface and its predecessor
                 gap_map.append(True)
 
             surfaces.append(outer_surface)

--- a/parastell/invessel_build.py
+++ b/parastell/invessel_build.py
@@ -768,30 +768,27 @@ class InVesselBuild(object):
         # mesh surfaces should be meshed or not
         gap_map = []
 
-        # Handle first component in mesh. Retrieve its inner and outer
-        # surfaces. Its inner surface is the outer surface of that adjacent
-        # (radially inward) to the first component
-        first_component = components[0]
-        component_surf_idx = surface_keys.index(first_component)
-        inner_component = surface_keys[component_surf_idx - 1]
-        # Add inner and outer surfaces of first component
-        surfaces.append(self.Surfaces[inner_component])
-        surfaces.append(self.Surfaces[first_component])
-        gap_map.append(False)
-
         # Identify surfaces and gaps in mesh
-        for component_idx, component in enumerate(components[1:], 1):
-            # Identify component adjacent (radially inward) to current
+        for component_idx, component in enumerate(components):
+            # Extract inner and outer surfaces of current component
+            outer_surface = self.Surfaces[component]
+            outer_surf_idx = surface_keys.index(component)
+            # Inner surface of current component is outer surface of the inner
             # component
-            component_surf_idx = surface_keys.index(component)
-            inner_component = surface_keys[component_surf_idx - 1]
+            inner_component = surface_keys[outer_surf_idx - 1]
+            inner_surface = self.Surfaces[inner_component]
+
+            # Handle first component
+            if len(surfaces) == 0:
+                surfaces.append(inner_surface)
             # If the inner component is not the previous component specified to
             # be meshed, identify a gap and add the inner surface
-            if inner_component != components[component_idx - 1]:
-                surfaces.append(self.Surfaces[inner_component])
+            elif surfaces[-1] != inner_surface:
+                print(surfaces[-1], inner_surface)
+                surfaces.append(inner_surface)
                 gap_map.append(True)
 
-            surfaces.append(self.Surfaces[component])
+            surfaces.append(outer_surface)
             gap_map.append(False)
 
         self.moab_mesh = InVesselComponentMesh(surfaces, gap_map, self._logger)

--- a/parastell/invessel_build.py
+++ b/parastell/invessel_build.py
@@ -1177,7 +1177,7 @@ class InVesselComponentMesh(ToroidalMesh):
 
     def create_mesh(self):
         """Creates volumetric mesh in real space."""
-        for surface_idx, _ in enumerate(self._surfaces[:-1]):
+        for surface_idx, _ in enumerate(self.surfaces[:-1]):
             if self.gap_map[surface_idx]:
                 continue  # Skip iteration if a gap is indicated
             for toroidal_idx in range(self._num_ribs - 1):

--- a/parastell/invessel_build.py
+++ b/parastell/invessel_build.py
@@ -772,10 +772,12 @@ class InVesselBuild(object):
         for component_idx, component in enumerate(components):
             # Extract inner and outer surfaces of current component
             outer_surface = self.Surfaces[component]
-            outer_surf_idx = surface_keys.index(component)
-            # Inner surface of current component is outer surface of the inner
-            # component
-            inner_component = surface_keys[outer_surf_idx - 1]
+            # Inner surface of current component is outer surface of the previous
+            # component. Since surfaces are created in order of components and
+            # named after the component for which they are the outer surface,
+            # it can be found by the ordered list of surface keys
+            inner_surf_idx = surface_keys.index(component) - 1
+            inner_component = surface_keys[inner_surf_idx]
             inner_surface = self.Surfaces[inner_component]
 
             # Handle first component
@@ -786,6 +788,7 @@ class InVesselBuild(object):
             elif surfaces[-1] != inner_surface:
                 print(surfaces[-1], inner_surface)
                 surfaces.append(inner_surface)
+                # don't mesh the gap between this surface and its predecessor
                 gap_map.append(True)
 
             surfaces.append(outer_surface)

--- a/parastell/parastell.py
+++ b/parastell/parastell.py
@@ -198,12 +198,12 @@ class Stellarator(object):
         self.invessel_build.export_step(export_dir=export_dir)
 
     def export_invessel_build_mesh_moab(
-        self, component, filename, export_dir=""
+        self, components, filename, export_dir=""
     ):
-        """Creates a tetrahedral mesh of a single in-vessel component volume
-        via MOAB and exports the mesh as a H5M file. Note that if this method
-        is used for adjacent components, the resultant meshes may have
-        overlapping tetrahedra.
+        """Creates a tetrahedral mesh of in-vessel component volumes via MOAB
+        and exports the mesh as a H5M file. Note that this mesh is created
+        using the point cloud of the specified components and as such, each
+        component's mesh will be one tetrahedron thick.
 
         Arguments:
             component (str): name of the in-vessel component to be meshed.
@@ -211,7 +211,7 @@ class Stellarator(object):
             export_dir (str): directory to which to export the h5m output file
                 (defaults to empty string).
         """
-        self.invessel_build.mesh_component_moab(component)
+        self.invessel_build.mesh_components_moab(components)
         self.invessel_build.export_mesh_moab(filename, export_dir=export_dir)
 
     def export_invessel_build_mesh_gmsh(

--- a/tests/test_invessel_build.py
+++ b/tests/test_invessel_build.py
@@ -197,7 +197,7 @@ def test_ivb_exports(invessel_build):
 
     remove_files()
 
-    invessel_build.mesh_component_moab(["component"])
+    invessel_build.mesh_components_moab(["component"])
     invessel_build.export_mesh_moab("component")
     assert Path("component.h5m").exists()
 

--- a/tests/test_invessel_build.py
+++ b/tests/test_invessel_build.py
@@ -191,13 +191,13 @@ def test_ivb_exports(invessel_build):
     if check_cubit_installation():
         create_new_cubit_instance()
 
-        invessel_build.mesh_components_cubit(components=["component"])
+        invessel_build.mesh_components_cubit(["component"])
         invessel_build.export_mesh_cubit("component")
         assert Path("component.h5m").exists()
 
     remove_files()
 
-    invessel_build.mesh_component_moab("component")
+    invessel_build.mesh_component_moab(["component"])
     invessel_build.export_mesh_moab("component")
     assert Path("component.h5m").exists()
 

--- a/tests/test_parastell.py
+++ b/tests/test_parastell.py
@@ -195,7 +195,7 @@ def test_invessel_build(stellarator):
 
         remove_files()
 
-    stellarator.export_invessel_build_mesh_moab("component", "component")
+    stellarator.export_invessel_build_mesh_moab(["component"], "component")
     assert component_h5m_filename_exp.exists()
 
     remove_files()


### PR DESCRIPTION
Enables the generation of meshes including multiple components for the MOAB workflow. This workflow avoids repeated vertices for adjacent components while supporting gaps from excluded components.