### PR TITLE
Improve handling of `scale` parameter

### DIFF
--- a/parastell/invessel_build.py
+++ b/parastell/invessel_build.py
@@ -83,7 +83,7 @@ class ReferenceSurface(ABC):
                 evaluate cartesian coordinates. Measured in radians.
             s (float): Generic parameter which may affect the evaluation of
                 the cartesian coordinate at a given angle pair.
-            scale (float): Amount to scale resulting coordinates by.
+            scale (float): a scaling factor between input and output data.
 
         Returns:
             coords (numpy array): Nx3 array of Cartesian coordinates at each
@@ -118,7 +118,7 @@ class VMECSurface(ReferenceSurface):
                     evaluate cartesian coordinates. Measured in radians.
             s (float): the normalized closed flux surface label defining the
                 point of reference for offset.
-            scale (float): Amount to scale resulting coordinates by.
+            scale (float): a scaling factor between input and output data.
 
         Returns:
             coords (numpy array): Nx3 array of Cartesian coordinates at each
@@ -247,7 +247,7 @@ class RibBasedSurface(ReferenceSurface):
             poloidal_angles (iterable of float): Poloidal angles at which to
                     evaluate cartesian coordinates. Measured in radians.
             s (float): Not used.
-            scale (float): Amount to scale resulting coordinates by.
+            scale (float): a scaling factor between input and output data.
 
         Returns:
             coords (numpy array): Nx3 array of Cartesian coordinates at each
@@ -293,7 +293,7 @@ class InVesselBuild(object):
             (defaults to 67). Points are set at poloidal angles interpolated
             between those specified in 'poloidal_angles' if this value is
             greater than the number of entries in 'poloidal_angles'.
-        scale (float): a scaling factor between the units of VMEC and [cm]
+        scale (float): a scaling factor between input and output data
             (defaults to m2cm = 100).
         use_pydagmc (bool): If True, generate components with pydagmc, rather
             than CadQuery (defaults to False).
@@ -310,6 +310,15 @@ class InVesselBuild(object):
         self.num_rib_pts = 61
         self.scale = m2cm
         self.use_pydagmc = False
+
+        if "scale" not in kwargs.keys():
+            w = Warning(
+                "No factor specified to scale InVesselBuild input data. "
+                "Assuming a scaling factor of 100.0, which is consistent with "
+                "input being in units of [m] and desired output in units of "
+                "[cm]."
+            )
+            self._logger.warning(w.args[0])
 
         for name in kwargs.keys() & (
             "repeat",
@@ -1038,7 +1047,7 @@ class Surface(object):
         offset_mat (np.array(double)): the set of offsets from the surface
             defined by s for each toroidal angle, poloidal angle pair on the
             surface [cm].
-        scale (float): a scaling factor between the units of VMEC and [cm].
+        scale (float): a scaling factor between input and output data.
     """
 
     def __init__(self, ref_surf, s, theta_list, phi_list, offset_mat, scale):
@@ -1116,7 +1125,7 @@ class Rib(object):
         offset_list (np.array(double)): the set of offsets from the curve
             defined by s for each toroidal angle, poloidal angle pair in the rib
             [cm].
-        scale (float): a scaling factor between the units of VMEC and [cm].
+        scale (float): a scaling factor between input and output data.
     """
 
     def __init__(self, ref_surf, s, theta_list, phi, offset_list, scale):

--- a/parastell/magnet_coils.py
+++ b/parastell/magnet_coils.py
@@ -196,8 +196,8 @@ class MagnetSetFromFilaments(MagnetSet):
             (defaults to 3).
         sample_mod (int): sampling modifier for filament points (defaults to
             1). For a user-defined value n, every nth point will be sampled.
-        scale (float): a scaling factor between the units of the point-locus
-            data and [cm] (defaults to m2cm = 100).
+        scale (float): a scaling factor between input and output data
+            (defaults to m2cm = 100).
         mat_tag (str): DAGMC material tag to use for magnets in DAGMC
             neutronics model (defaults to 'magnets').
     """
@@ -225,6 +225,15 @@ class MagnetSetFromFilaments(MagnetSet):
 
         # Define maximum length of coil cross-section
         self.max_cs_len = max(self._width, self._thickness)
+
+        if "scale" not in kwargs.keys():
+            w = Warning(
+                "No factor specified to scale MagnetSet input data. "
+                "Assuming a scaling factor of 100.0, which is consistent with "
+                "input being in units of [m] and desired output in units of "
+                "[cm]."
+            )
+            self._logger.warning(w.args[0])
 
         for name in kwargs.keys() & (
             "start_line",

--- a/parastell/nwl_utils.py
+++ b/parastell/nwl_utils.py
@@ -262,6 +262,7 @@ def compute_nwl(
     num_batches=1,
     num_crossings=None,
     num_threads=None,
+    scale=1.0,
     logger=None,
 ):
     """Computes NWL. Assumes toroidal extent is less than 360 degrees.
@@ -293,6 +294,8 @@ def compute_nwl(
         num_threads (int): number of threads to use for parallelizing
             coordinate-solving routine (defaults to None). If None, the maximum
             number of threads will be used.
+        scale (float): a scaling factor between ref_surf data and [m] (defaults
+            to 1.0).
 
     Returns:
         nwl_mat (numpy array): array used to create the NWL plot
@@ -380,7 +383,7 @@ def compute_nwl(
     bin_mat = np.zeros((num_toroidal_bins + 1, num_poloidal_bins + 1, 3))
     for toroidal_id, toroidal_edge in enumerate(toroidal_bin_edges):
         bin_mat[toroidal_id, :, :] = ref_surf.angles_to_xyz(
-            toroidal_edge, poloidal_bin_edges, wall_s, m2cm
+            toroidal_edge, poloidal_bin_edges, wall_s, scale
         )
 
     # Construct matrix of bin areas

--- a/parastell/parastell.py
+++ b/parastell/parastell.py
@@ -166,7 +166,7 @@ class Stellarator(object):
                 (defaults to 61). Points are set at poloidal angles interpolated
                 between those specified in 'poloidal_angles' if this value is
                 greater than the number of entries in 'poloidal_angles'.
-            scale (float): a scaling factor between the units of VMEC and [cm]
+            scale (float): a scaling factor between input and output data
                 (defaults to m2cm = 100).
             use_pydagmc (bool): if True, generate dagmc model directly with
                 pydagmc, bypassing CAD generation. Results in faceted geometry,
@@ -307,8 +307,8 @@ class Stellarator(object):
                 (defaults to 3).
             sample_mod (int): sampling modifier for filament points (defaults to
                 1). For a user-defined value n, every nth point will be sampled.
-            scale (float): a scaling factor between the units of the point-locus
-                data and [cm] (defaults to m2cm = 100).
+            scale (float): a scaling factor between input and output data
+                (defaults to m2cm = 100).
             mat_tag (str): DAGMC material tag to use for magnets in DAGMC
                 neutronics model (defaults to 'magnets').
         """
@@ -439,7 +439,7 @@ class Stellarator(object):
                 degrees.
 
         Optional attributes:
-            scale (float): a scaling factor between the units of VMEC and [cm]
+            scale (float): a scaling factor between input and output data
                 (defaults to m2cm = 100).
             plasma_conditions (function): function that takes the plasma
                 parameter s, and returns temperature and ion density with

--- a/parastell/source_mesh.py
+++ b/parastell/source_mesh.py
@@ -103,7 +103,7 @@ class SourceMesh(ToroidalMesh):
             supplied, a default logger will be instantiated.
 
     Optional attributes:
-        scale (float): a scaling factor between the units of VMEC and [cm]
+        scale (float): a scaling factor between input and output data
             (defaults to m2cm = 100).
         plasma_conditions (function): function that takes the plasma parameter
             s, and returns temperature and ion density with suitable units for
@@ -132,6 +132,15 @@ class SourceMesh(ToroidalMesh):
         self.scale = m2cm
         self.plasma_conditions = default_plasma_conditions
         self.reaction_rate = default_reaction_rate
+
+        if "scale" not in kwargs.keys():
+            w = Warning(
+                "No factor specified to scale SourceMesh input data. "
+                "Assuming a scaling factor of 100.0, which is consistent with "
+                "input being in units of [m] and desired output in units of "
+                "[cm]."
+            )
+            self._logger.warning(w.args[0])
 
         for name in kwargs.keys() & (
             "scale",

--- a/parastell/utils.py
+++ b/parastell/utils.py
@@ -459,7 +459,7 @@ def dagmc_volume_to_step(
 
 
 def ribs_from_kisslinger_format(
-    filename, start_line=2, scale=m2cm, delimiter="\t"
+    filename, start_line=2, scale=1.0, delimiter="\t"
 ):
     """Reads a Kisslinger format file and extracts the R, Z data, the number of
     periods, and the toroidal angles at which the R, Z data is specified.
@@ -492,7 +492,9 @@ def ribs_from_kisslinger_format(
             should be the line that includes the number of toroidal angles,
             number of points per toroidal angle, and number of periods.
             Defaults to 2.
-        scale (float): Amount to scale the r-z coordinates by. Defaults to 100.
+        scale (float): a scaling factor between input and output data
+            (defaults to 1.0).
+
     Returns:
         toroidal_angles (numpy array): Toroidal angles in the
             angles in the input file in degrees.


### PR DESCRIPTION
Changes the way the `scale` keyword argument in handled across ParaStell classes. Specifically, generalizes documentation to remove VMEC-specific verbiage, adds warnings when default scaling is used for improved transparency to users, and introduces scaling for NWL computation.