### PR TITLE
Relax dependencies

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -2,15 +2,14 @@ name: parastell_env
 channels:
   - conda-forge
 dependencies:
-  - python=3.11.6
-  - pip
-  - numpy=1.26.4
-  - scipy
   - cadquery
-  - moab=5.5.1[build=nompi_tempest_*]
+  - moab >=5.5.1[build=nompi_tempest_*]
   - cad_to_dagmc >=0.9.1
-  - openmc=0.15.0[build=dagmc_nompi_*]
+  - openmc >=0.15.0[build=dagmc_nompi_*]
+  - numpy
+  - scipy
   - matplotlib
+  - pip
   - pip:
       - netcdf4
       - pyyaml


### PR DESCRIPTION
Relaxes the dependencies specified in `environment.yml`. One major change is that we no longer require a specific version of Python