### PR TITLE
Don't remove duplicate nodes in PyDAGMC-Gmsh routine

### DIFF
--- a/parastell/invessel_build.py
+++ b/parastell/invessel_build.py
@@ -912,8 +912,6 @@ class InVesselBuild(object):
             gmsh.merge(mesh_file)
             Path(mesh_file).unlink()
 
-        gmsh.model.mesh.removeDuplicateNodes()
-
     def _gmsh_from_cadquery(
         self, components, min_mesh_size, max_mesh_size, algorithm
     ):


### PR DESCRIPTION
This branch removes the call for Gmsh to delete duplicate nodes in the PyDAGMC-Gmsh routine. This fixes a recently discovered issue that OpenMC can have a hard time loading such meshes for some of its functionality.

`gmsh.model.mesh.removeDuplicateNodes()` was used to try to reduce mesh file size but is not strictly necessary. My guess is that Gmsh may have just been removing those nodes it deemed duplicates without actually replacing the entities for the associated tetrahedra