### PR TITLE
Modify calculation of poloidal profile tangents

### DIFF
--- a/parastell/invessel_build.py
+++ b/parastell/invessel_build.py
@@ -77,17 +77,36 @@ class ReferenceSurface(ABC):
         constant to x, y, z coordinates.
 
         Arguments:
-            toroidal_angles (float): Toroidal angle at which to
-                evaluate cartesian coordinates. Measured in radians.
-            poloidal_angles (iterable of float): Poloidal angles at which to
-                evaluate cartesian coordinates. Measured in radians.
+            toroidal_angles (float): toroidal angle at which to evaluate
+                Cartesian coordinates [rad].
+            poloidal_angles (iterable of float): poloidal angles at which to
+                evaluate Cartesian coordinates [rad].
             s (float): Generic parameter which may affect the evaluation of
                 the cartesian coordinate at a given angle pair.
             scale (float): a scaling factor between input and output data.
 
         Returns:
-            coords (numpy array): Nx3 array of Cartesian coordinates at each
+            coords (Nx3 numpy.array): array of Cartesian coordinates at each
                 angle pair specified.
+        """
+        pass
+
+    def calculate_tangents(self, toroidal_angle, poloidal_angles, s, scale):
+        """Compute the tangents of a set of points, defined by a set of
+        poloidal angles, at a given toroidal angle.
+
+        Arguments:
+            toroidal_angles (float): toroidal angle at which to evaluate
+                tangents [rad].
+            poloidal_angles (iterable of float): poloidal angles at which to
+                evaluate tangents [rad].
+            s (float): Generic parameter which may affect the evaluation of
+                the cartesian coordinate at a given angle pair.
+            scale (float): a scaling factor between input and output data.
+
+        Returns:
+            (Nx3 numpy.array): array of poloidal tangents at each angle pair
+                specified.
         """
         pass
 

--- a/parastell/invessel_build.py
+++ b/parastell/invessel_build.py
@@ -69,8 +69,8 @@ class ReferenceSurface(ABC):
     layers are built.
     """
 
-    def __init__():
-        pass
+    def __init__(self):
+        self.poloidal_perturbation = 1e-4
 
     def angles_to_xyz(self, toroidal_angle, poloidal_angles, s, scale):
         """Method to go from a location defined by two angles and some
@@ -137,9 +137,9 @@ class VMECSurface(ReferenceSurface):
     """
 
     def __init__(self, vmec_obj):
-        self.vmec_obj = vmec_obj
+        super().__init__()
 
-        self.poloidal_perturbation = 1e-4
+        self.vmec_obj = vmec_obj
 
     def angles_to_xyz(self, toroidal_angle, poloidal_angles, s, scale):
         """Evaluate the Cartesian coordinates for a set of toroidal and
@@ -192,13 +192,13 @@ class RibBasedSurface(ReferenceSurface):
     """
 
     def __init__(self, rib_data, toroidal_angles, poloidal_angles, **kwargs):
+        super().__init__()
+
         self.rib_data = rib_data
         self.toroidal_angles = toroidal_angles
         self.poloidal_angles = poloidal_angles
 
-        self.poloidal_perturbation = 1e-4
-
-        for name in kwargs.keys() & ("poloidal_perturbation"):
+        for name in kwargs.keys() & ("poloidal_perturbation", "stuff"):
             self.__setattr__(name, kwargs[name])
 
         self.build_analytic_surface()


### PR DESCRIPTION
Changes the calculation of poloidal profile tangents, used to compute IVB surface normals, in the following ways:

- Handle calculation differently for VMEC and rib-based surfaces. Specifically, the poloidal perturbation is made larger for rib-based surfaces. It was found during testing that the perturbation used for VMEC surfaces, 1e-4, was small for the interpolator and gave unexpected results.
- Migrate the calculation to the respective classes, similar to `angles_to_xyz`, in the form of a new class method `calculate_tangents`
- Modify the calculation to use a central difference, rather than a forward difference