### PR TITLE
Multithread Gmsh meshing

### DIFF
--- a/parastell/invessel_build.py
+++ b/parastell/invessel_build.py
@@ -917,6 +917,10 @@ class InVesselBuild(object):
 
         gmsh.initialize()
 
+        gmsh.option.setNumber(
+            "General.NumThreads", 0
+        )  # Use all available cores
+
         if self._use_pydagmc:
             self._gmsh_from_pydagmc(
                 components, min_mesh_size, max_mesh_size, algorithm

--- a/parastell/magnet_coils.py
+++ b/parastell/magnet_coils.py
@@ -140,6 +140,10 @@ class MagnetSet(ABC):
 
         gmsh.initialize()
 
+        gmsh.option.setNumber(
+            "General.NumThreads", 0
+        )  # Use all available cores
+
         for solid in self.coil_solids:
             gmsh.model.occ.importShapesNativePointer(solid.wrapped._address())
 


### PR DESCRIPTION
Makes Gmsh use all available threads for meshing, rather than using just a single thread