### PR TITLE
Fix storage of coil solids for imported geometries

### DIFF
--- a/parastell/magnet_coils.py
+++ b/parastell/magnet_coils.py
@@ -497,7 +497,7 @@ class MagnetSetFromGeometry(MagnetSet):
             if isinstance(item, cq.occ_impl.shapes.Compound):
                 self.coil_solids.extend(item.Solids())
             elif isinstance(item, cq.occ_impl.shapes.Solid):
-                self.coil_solids.extend(item)
+                self.coil_solids.append(item)
             else:
                 e = ValueError(
                     f"Imported object of type {type(item)} not recognized."

--- a/parastell/magnet_coils.py
+++ b/parastell/magnet_coils.py
@@ -484,9 +484,11 @@ class MagnetSetFromGeometry(MagnetSet):
     @property
     def coil_solids(self):
         if self._coil_solids is None:
-            self._coil_solids = cq.importers.importStep(
-                str(self.geometry_file)
-            ).vals()
+            self._coil_solids = (
+                cq.importers.importStep(str(self.geometry_file))
+                .vals()[0]
+                .Solids()
+            )
         return self._coil_solids
 
 


### PR DESCRIPTION
Previously, some coil geometries (depending on how they were created) were imported as stored as a single `cq.Compound` object, rather than as a list of `cq.Solid` objects. This caused material assignments for imported magnet geometries to fail for the CAD-to-DAGMC workflow.