### PR TITLE
Log out of license server after CI tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,7 @@ jobs:
           /opt/Coreform-Cubit-2025.8/bin/rlm_activate --login ${EMAIL_SECRET} ${PASSWORD_SECRET}
           cd /opt/parastell/tests
           pytest -v .
+          /opt/Coreform-Cubit-2025.8/bin/rlm_activate --logout
         env:
           EMAIL_SECRET: ${{ secrets.LICENSE_EMAIL }}
           PASSWORD_SECRET: ${{ secrets.LICENSE_PASSWORD }}

--- a/.github/workflows/docker_publish.yml
+++ b/.github/workflows/docker_publish.yml
@@ -73,6 +73,7 @@ jobs:
           /opt/Coreform-Cubit-2025.8/bin/rlm_activate --login ${EMAIL_SECRET} ${PASSWORD_SECRET}
           cd /opt/parastell/tests
           pytest -v .
+          /opt/Coreform-Cubit-2025.8/bin/rlm_activate --logout
         env:
           EMAIL_SECRET: ${{ secrets.LICENSE_EMAIL }}
           PASSWORD_SECRET: ${{ secrets.LICENSE_PASSWORD }}


### PR DESCRIPTION
Adds a command in the CI workflow files to log out of Cubit's RLM server after tests are run