### PR TITLE
Change handling of 360-degree geometries for magnets

### DIFF
--- a/parastell/magnet_coils.py
+++ b/parastell/magnet_coils.py
@@ -512,7 +512,10 @@ class MagnetSetFromFilaments(MagnetSet):
         """
         self._logger.info("Constructing magnet coils...")
 
-        toroidal_domain = self._create_magnet_boundary()
+        if self.toroidal_extent < 2 * np.pi:
+            toroidal_domain = self._create_magnet_boundary()
+        else:
+            toroidal_domain = None
 
         [
             magnet_coil.create_magnet(toroidal_domain)
@@ -884,7 +887,8 @@ class MagnetCoil(object):
                 self.width - 2 * self.case_thickness,
                 self.thickness - 2 * self.case_thickness,
             )
-            inner_solid = inner_solid.intersect(toroidal_domain)
+            if toroidal_domain:
+                inner_solid = inner_solid.intersect(toroidal_domain)
 
             outer_solid = magnet_solid.cut(inner_solid)
 

--- a/parastell/magnet_coils.py
+++ b/parastell/magnet_coils.py
@@ -349,11 +349,12 @@ class MagnetSetFromFilaments(MagnetSet):
 
     @toroidal_extent.setter
     def toroidal_extent(self, angle):
-        self._toroidal_extent = np.deg2rad(angle)
-        if self._toroidal_extent > 360.0:
+        if angle > 360.0:
             e = ValueError("Toroidal extent cannot exceed 360.0 degrees.")
             self._logger.error(e.args[0])
             raise e
+
+        self._toroidal_extent = np.deg2rad(angle)
 
     @property
     def case_thickness(self):


### PR DESCRIPTION
This branch modifies the magnet creation workflow such that when `toroidal_extent = 360.0`, the intersection operation of each magnet coil with `toroidal_domain` does not occur. This does not cause any issues, but is an unnecessary operation.