### PR TITLE
Automate volume ID assignment for imported magnet geometries and imprint

### DIFF
--- a/parastell/magnet_coils.py
+++ b/parastell/magnet_coils.py
@@ -661,8 +661,8 @@ class MagnetSetFromGeometry(MagnetSet):
 
             if len(paired_volumes) > 2:
                 self._logger.error(
-                    f"{len(paired_volumes)} volumes found in same location. "
-                    "Only pairs are supported."
+                    f"{len(paired_volumes)} nested volumes detected near "
+                    f"location {center}. Only pairs are supported."
                 )
             else:
                 self.volume_ids.append(paired_volumes)
@@ -681,7 +681,8 @@ class MagnetSetFromGeometry(MagnetSet):
                     self.volume_ids[k] = [j, i]
                 else:
                     self._logger.error(
-                        f"Cannot resolve outer and inner volumes for pair {k}"
+                        "Cannot resolve nested arrangement for detected pair "
+                        f"with IDs ({i,j})"
                     )
 
             self.coil_solids = [

--- a/parastell/magnet_coils.py
+++ b/parastell/magnet_coils.py
@@ -636,10 +636,10 @@ class MagnetSetFromGeometry(MagnetSet):
         center_angles = [np.arctan2(center.y, center.x) for center in centers]
 
         sorted_angles = np.array(sorted(center_angles))
-        sorted_coils = np.array(
+        sorted_solids = np.array(
             [
-                id
-                for _, id in sorted(
+                solid
+                for _, solid in sorted(
                     zip(center_angles, self.coil_solids),
                     key=lambda pair: pair[0],
                 )
@@ -651,16 +651,17 @@ class MagnetSetFromGeometry(MagnetSet):
             [sorted_angles - angle for angle in sorted_angles]
         )
 
-        nested_groups = np.isclose(diff_matrix, 0.0, atol=2.0 * np.pi / 180.0)
+        # Compute NxN map to indicate whether solids are close to each other
+        closeness_map = np.isclose(diff_matrix, 0.0, atol=2.0 * np.pi / 180.0)
         # np.unique does not preserve order; reference unique groups by index
         _, unique_group_idxs = np.unique(
-            nested_groups, return_index=True, axis=0
+            closeness_map, return_index=True, axis=0
         )
-        group_idx_map = nested_groups[np.sort(unique_group_idxs)]
+        group_idx_map = closeness_map[np.sort(unique_group_idxs)]
 
         try:
             self.coil_solids = np.array(
-                [sorted_coils[idx_map] for idx_map in group_idx_map]
+                [sorted_solids[idx_map] for idx_map in group_idx_map]
             )
         except ValueError as e:
             self._logger.info(

--- a/parastell/magnet_coils.py
+++ b/parastell/magnet_coils.py
@@ -687,6 +687,7 @@ class MagnetSetFromGeometry(MagnetSet):
             self._logger.info(
                 "Nested magnet volumes detected. All have been paired successfully."
             )
+            self.has_casing = True
 
         self.volume_ids = volume_ids
 

--- a/parastell/magnet_coils.py
+++ b/parastell/magnet_coils.py
@@ -684,6 +684,11 @@ class MagnetSetFromGeometry(MagnetSet):
                         f"Cannot resolve outer and inner volumes for pair {k}"
                     )
 
+            self.coil_solids = [
+                [self.coil_solids[outer_id][0], self.coil_solids[inner_id][0]]
+                for outer_id, inner_id in self.volume_ids
+            ]
+
 
 class Filament(object):
     """Object containing basic data defining a Filament, and necessary

--- a/parastell/magnet_coils.py
+++ b/parastell/magnet_coils.py
@@ -564,8 +564,13 @@ class MagnetSetFromFilaments(MagnetSet):
 
 
 class MagnetSetFromGeometry(MagnetSet):
-    """An object representing a set of modular stellarator magnet coils
-    with previously defined geometry files.
+    """An object representing a set of modular stellarator magnet coils with
+    previously defined geometry files. Note that if the geometry has nested
+    coil volumes (e.g., casing and winding pack), and the underlying CAD
+    surfaces are not merged such that shared surfaces are the same CAD entity,
+    the user is limited to the Cubit routine for the generation of valid DAGMC
+    models. Furthermore, for nested geometries, it is expected that only two
+    volumes are present per coil - any additional is not supported.
 
     Arguments:
         geometry_file (str): path to the existing coil geometry. If using Cubit

--- a/parastell/magnet_coils.py
+++ b/parastell/magnet_coils.py
@@ -646,7 +646,7 @@ class MagnetSetFromGeometry(MagnetSet):
             ]
         )
 
-        # Compute matrix of differences between each angle and all angles
+        # Compute NxN matrix of differences between each angle and all angles
         diff_matrix = np.array(
             [sorted_angles - angle for angle in sorted_angles]
         )
@@ -680,7 +680,7 @@ class MagnetSetFromGeometry(MagnetSet):
             )
         else:
             self._logger.info(
-                "Nested magnet volumes detected. All have been grouped "
+                "Pairs of nested magnet volumes detected. All have been grouped "
                 "successfully."
             )
             self.has_casing = True

--- a/parastell/magnet_coils.py
+++ b/parastell/magnet_coils.py
@@ -565,12 +565,9 @@ class MagnetSetFromFilaments(MagnetSet):
 
 class MagnetSetFromGeometry(MagnetSet):
     """An object representing a set of modular stellarator magnet coils with
-    previously defined geometry files. Note that if the geometry has nested
-    coil volumes (e.g., casing and winding pack), and the underlying CAD
-    surfaces are not merged such that shared surfaces are the same CAD entity,
-    the user is limited to the Cubit routine for the generation of valid DAGMC
-    models. Furthermore, for nested geometries, it is expected that only two
-    volumes are present per coil - any additional is not supported.
+    previously defined geometry files. For nested geometries, it is expected
+    that only two volumes are present per coil - any additional is not
+    supported.
 
     Arguments:
         geometry_file (str): path to the existing coil geometry. If using Cubit

--- a/parastell/parastell.py
+++ b/parastell/parastell.py
@@ -350,9 +350,6 @@ class Stellarator(object):
                 an iterable is given, the first entry will be applied to coil
                 casing and the second to the inner volume. If just one is
                 given, it will be applied to all magnet volumes.
-            volume_ids (2-D iterable of int): list of ID pairs for
-                (outer, inner) volume pairs, as imported by CadQuery or Cubit,
-                beginning from 0.
         """
         self.magnet_set = mc.MagnetSetFromGeometry(
             geometry_file,

--- a/parastell/parastell.py
+++ b/parastell/parastell.py
@@ -540,6 +540,11 @@ class Stellarator(object):
             self.invessel_build.merge_surfaces()
 
         if self.magnet_set:
+            # If imported geometry, export new magnet STEP file with properly
+            # ordered volumes
+            if isinstance(self.magnet_set, mc.MagnetSetFromGeometry):
+                self.magnet_set.export_step()
+
             self.magnet_set.import_geom_cubit()
             self.magnet_set.merge_surfaces()
 

--- a/tests/test_parastell.py
+++ b/tests/test_parastell.py
@@ -389,13 +389,14 @@ def test_cubit_ps_geom(stellarator):
     remove_files()
 
 
-# Cubit imports whole magnets with 8 surfaces per volume, and nested magnets
-# with 4 surfaces on the inner volume and 8 surfaces on the outer volume (avg. 6)
+# Cubit exports whole magnet geometry with 8 surfaces per volume (due to STEP
+# file), and nested magnets with 4 shared surfaces on the inner volume and 4
+# unique surfaces on the outer volume (due to STEP file)
 @pytest.mark.parametrize(
     "geometry_file, num_surfaces_per_magnet, num_magnet_volumes, cubit_volume_ids_exp",
     [
         ("magnet_geom", 8, 2, [[3], [4]]),
-        ("magnet_geom_with_casing", 6, 4, [[3, 4], [5, 6]]),
+        ("magnet_geom_with_casing", 4, 4, [[3, 4], [5, 6]]),
     ],
 )
 def test_cubit_cad_magnets(
@@ -492,8 +493,9 @@ def test_cad_to_dagmc_ps_geom(stellarator):
     remove_files()
 
 
-# CAD-to-DAGMC imports whole magnets with 8 surfaces per volume, and nested
-# magnets with 4 surfaces on the inner and outer volumes
+# CAD-to-DAGMC exports whole magnet geometry with 8 surfaces per volume (due to
+# STEP file), and nested magnets with 4 shared surfaces on the inner volume and
+# 4 unique surfaces on the outer volume (due to STEP file)
 @pytest.mark.parametrize(
     "geometry_file, num_surfaces_per_magnet, num_magnet_volumes",
     [("magnet_geom", 8, 2), ("magnet_geom_with_casing", 4, 4)],
@@ -665,13 +667,14 @@ def test_pydagmc_ps_geom_cad_to_dagmc_360(stellarator):
     remove_files()
 
 
-# Cubit imports whole magnets with 8 surfaces per volume, and nested magnets
-# with 4 surfaces on the inner volume and 8 surfaces on the outer volume (avg. 6)
+# Cubit exports whole magnet geometry with 8 surfaces per volume (due to STEP
+# file), and nested magnets with 4 shared surfaces on the inner volume and 4
+# unique surfaces on the outer volume (due to STEP file)
 @pytest.mark.parametrize(
     "geometry_file, num_surfaces_per_magnet, num_magnet_volumes, cubit_volume_ids_exp",
     [
         ("magnet_geom", 8, 2, [[1], [2]]),
-        ("magnet_geom_with_casing", 6, 4, [[1, 2], [3, 4]]),
+        ("magnet_geom_with_casing", 4, 4, [[1, 2], [3, 4]]),
     ],
 )
 def test_pydagmc_cad_magnets_cubit(
@@ -722,8 +725,9 @@ def test_pydagmc_cad_magnets_cubit(
     remove_files()
 
 
-# CAD-to-DAGMC imports whole magnets with 8 surfaces per volume, and nested
-# magnets with 4 surfaces on the inner and outer volumes
+# CAD-to-DAGMC exports whole magnet geometry with 8 surfaces per volume (due to
+# STEP file), and nested magnets with 4 shared surfaces on the inner volume and
+# 4 unique surfaces on the outer volume (due to STEP file)
 @pytest.mark.parametrize(
     "geometry_file, num_surfaces_per_magnet, num_magnet_volumes",
     [("magnet_geom", 8, 2), ("magnet_geom_with_casing", 4, 4)],

--- a/tests/test_parastell.py
+++ b/tests/test_parastell.py
@@ -439,6 +439,7 @@ def test_cubit_cad_magnets(
 
     stellarator.build_cubit_model()
 
+    assert Path("magnet_set.step").exists()  # Assert new STEP file created
     assert (
         stellarator.invessel_build.radial_build.radial_build["chamber"][
             "vol_id"
@@ -705,11 +706,13 @@ def test_pydagmc_cad_magnets_cubit(
     stellarator.build_pydagmc_model(
         magnet_exporter="cubit", deviation_angle=6, max_mesh_size=40
     )
-    stellarator.export_pydagmc_model("dagmc.h5m")
 
+    assert Path("magnet_set.step").exists()  # Assert new STEP file created
     assert np.allclose(
         stellarator.magnet_set.cubit_volume_ids, cubit_volume_ids_exp
     )
+
+    stellarator.export_pydagmc_model("dagmc.h5m")
 
     assert Path("dagmc.h5m").exists()
 

--- a/tests/test_parastell.py
+++ b/tests/test_parastell.py
@@ -427,6 +427,7 @@ def test_cubit_cad_magnets(
     component_name_exp = "component"
     filename_exp = "dagmc"
 
+    # Three unique surfaces per IVC
     num_surfaces_per_ivc = 3
     num_ivc_volumes = 2
     num_ivc_surfaces = num_surfaces_per_ivc * num_ivc_volumes
@@ -514,6 +515,7 @@ def test_cad_to_dagmc_cad_magnets(
 
     filename_exp = "dagmc"
 
+    # Three unique surfaces per IVC
     num_surfaces_per_ivc = 3
     num_ivc_volumes = 2
     num_ivc_surfaces = num_surfaces_per_ivc * num_ivc_volumes
@@ -711,6 +713,7 @@ def test_pydagmc_cad_magnets_cubit(
 
     assert Path("dagmc.h5m").exists()
 
+    # Four unique surfaces for one IVC
     num_surfaces_per_ivc = 4
     num_ivc_volumes = 1
     num_ivc_surfaces = num_surfaces_per_ivc * num_ivc_volumes
@@ -753,6 +756,7 @@ def test_pydagmc_cad_magnets_cad_to_dagmc(
 
     assert Path("dagmc.h5m").exists()
 
+    # Four unique surfaces for one IVC
     num_surfaces_per_ivc = 4
     num_ivc_volumes = 1
     num_ivc_surfaces = num_surfaces_per_ivc * num_ivc_volumes


### PR DESCRIPTION
Automates the process of assigning volume IDs to imported magnet geometries, by detecting nested volume pairs, rather than relying on the user to provide them. The tests written as-is should be sufficient to detect any issues with this new routine.

Also adds an imprinting routine for nested magnet geometries, to ensure that imported geometries have shared CAD surfaces for CAD-to-DAGMC and Gmsh routines.