### PR TITLE
Add radial component to closeness evaluation

### DIFF
--- a/parastell/magnet_coils.py
+++ b/parastell/magnet_coils.py
@@ -663,7 +663,10 @@ class MagnetSetFromGeometry(MagnetSet):
             [sorted_angles - angle for angle in sorted_angles]
         )
         radial_diff_matrix = np.array(
-            [sorted_radii - radius for radius in sorted_radii]
+            [
+                radii_sorted_by_angle - radius
+                for radius in radii_sorted_by_angle
+            ]
         )
 
         # Compute NxN map to indicate whether solids are close to each other
@@ -672,7 +675,7 @@ class MagnetSetFromGeometry(MagnetSet):
             toroidal_diff_matrix, 0.0, atol=2 * np.pi / 180.0
         )
         radial_closeness_map = np.isclose(radial_diff_matrix, 0.0, atol=5.0)
-        closeness_map = radial_closeness_map * toroidal_closeness_map
+        closeness_map = radial_closeness_map & toroidal_closeness_map
 
         # Extract unique groups since they will be repeated if nested volumes
         # are present
@@ -688,7 +691,7 @@ class MagnetSetFromGeometry(MagnetSet):
 
         try:
             self.coil_solids = np.array(
-                [sorted_solids[idx_map] for idx_map in group_idx_map]
+                [solids_sorted_by_angle[idx_map] for idx_map in group_idx_map]
             )
         except ValueError as e:
             self._logger.info(

--- a/parastell/magnet_coils.py
+++ b/parastell/magnet_coils.py
@@ -639,7 +639,7 @@ class MagnetSetFromGeometry(MagnetSet):
         ]
 
         sorted_angles = np.array(sorted(center_angles))
-        sorted_radii = np.array(
+        radii_sorted_by_angle = np.array(
             [
                 radius
                 for _, radius in sorted(
@@ -648,7 +648,7 @@ class MagnetSetFromGeometry(MagnetSet):
                 )
             ]
         )
-        sorted_solids = np.array(
+        solids_sorted_by_angle = np.array(
             [
                 solid
                 for _, solid in sorted(


### PR DESCRIPTION
Not to make the volume ID assignment algorithm more of a beast, but I realized in testing that the condition for evaluating the closeness of solids was insufficient for geometries that are cut at the ends of the toroidal domain of the model. In such cases, the toroidal angles of the centers of mass of the cut solids tend to be quite close to each other. To solve this issue, I added a radial component to the evaluation.